### PR TITLE
Permission check

### DIFF
--- a/apis/intermediate_api/CHANGELOG.md
+++ b/apis/intermediate_api/CHANGELOG.md
@@ -1,3 +1,9 @@
+## November 16, 2021
+
+### Permission check - ([PR #30](https://github.com/ucgmsim/gmhazard/pull/30))
+
+- Adding permission check before forwarding requests to Core/Project API.
+
 ## October 27, 2021
 
 ### Remove Authentication for the Projects tab - ([PR #23](https://github.com/ucgmsim/gmhazard/pull/23))
@@ -12,4 +18,4 @@
 
 - Rename Middleware to IntermediateAPI.
 - Upload `.env.example`.
-- Update ReadME to provide better information.
+- Update ReadME to provide better information.~~

--- a/apis/intermediate_api/intermediate_api/api/core_api.py
+++ b/apis/intermediate_api/intermediate_api/api/core_api.py
@@ -29,13 +29,14 @@ def get_ensemble_ids(is_authenticated):
         return utils.proxy_to_api(
             request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_IMS_ENDPOINT, methods=["GET"])
@@ -45,13 +46,14 @@ def get_im_ids(is_authenticated):
         return utils.proxy_to_api(
             request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_CONTEXT_MAP_ENDPOINT, methods=["GET"])
@@ -65,13 +67,14 @@ def get_context_map(is_authenticated):
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_VS30_MAP_ENDPOINT, methods=["GET"])
@@ -81,13 +84,14 @@ def get_vs30_map(is_authenticated):
         return utils.proxy_to_api(
             request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_VS30_SOIL_CLASS_ENDPOINT, methods=["GET"])
@@ -101,13 +105,14 @@ def get_soil_class_from_vs30(is_authenticated):
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_STATION_ENDPOINT, methods=["GET"])
@@ -123,13 +128,14 @@ def get_station(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Set Station",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 # Seismic Hazard
@@ -146,13 +152,14 @@ def get_hazard(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Hazard Curve Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_ENDPOINT, methods=["GET"])
@@ -168,13 +175,14 @@ def get_hazard_nzs1170p5(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Hazard NZS1170p5 Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_SOIL_CLASS_ENDPOINT, methods=["GET"])
@@ -184,13 +192,14 @@ def get_nzs1170p5_soil_class(is_authenticated):
         return utils.proxy_to_api(
             request, const.NZS1170p5_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
@@ -204,13 +213,14 @@ def get_nzs1170p5_default_params(is_authenticated):
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_ENDPOINT, methods=["GET"])
@@ -226,13 +236,14 @@ def get_hazard_nzta(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Hazard NZTA Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_SOIL_CLASS_ENDPOINT, methods=["GET"])
@@ -242,13 +253,14 @@ def get_nzta_soil_class(is_authenticated):
         return utils.proxy_to_api(
             request, const.NZTA_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
@@ -262,13 +274,14 @@ def get_nzta_default_params(is_authenticated):
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
@@ -284,13 +297,14 @@ def get_disagg(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Disaggregation Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
@@ -306,13 +320,14 @@ def get_uhs(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - UHS Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_UHS_NZS1170P5_ENDPOINT, methods=["GET"])
@@ -328,13 +343,14 @@ def get_uhs_nzs1170p5(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - UHS NZS1170p5 Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 # GMS
@@ -352,13 +368,14 @@ def compute_ensemble_gms(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - GMS Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_IM_WEIGHTS_ENDPOINT, methods=["GET"])
@@ -372,13 +389,14 @@ def get_default_im_weights(is_authenticated):
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
@@ -392,13 +410,14 @@ def get_default_causal_params(is_authenticated):
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_GMS_DATASETS_ENDPOINT, methods=["GET"])
@@ -412,13 +431,14 @@ def get_gm_datasets(is_authenticated):
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_GMS_IMS_ENDPOINT_ENDPOINT, methods=["GET"])
@@ -428,13 +448,14 @@ def get_gms_available_ims(is_authenticated):
         return utils.proxy_to_api(
             request, const.GMS_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 # Scenarios
@@ -451,13 +472,14 @@ def get_scenario(is_authenticated):
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Scenarios Get",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 # Download
@@ -476,13 +498,14 @@ def core_api_download_hazard(is_authenticated):
             action="Hazard Analysis - Hazard Download",
             content_type="application/zip",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_DOWNLOAD_ENDPOINT, methods=["GET"])
@@ -499,13 +522,14 @@ def core_api_download_disagg(is_authenticated):
             action="Hazard Analysis - Disaggregation Download",
             content_type="application/zip",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.CORE_API_HAZARD_UHS_DOWNLOAD_ENDPOINT, methods=["GET"])
@@ -522,13 +546,14 @@ def core_api_download_uhs(is_authenticated):
             action="Hazard Analysis - UHS Download",
             content_type="application/zip",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(f"{const.CORE_API_GMS_DOWNLOAD_ENDPOINT}/<token>", methods=["GET"])
@@ -545,13 +570,14 @@ def core_api_download_gms(is_authenticated, token):
             action="Hazard Analysis - GMS Download",
             content_type="application/zip",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(f"{const.CORE_API_SCENARIOS_DOWNLOAD_ENDPOINT}", methods=["GET"])
@@ -568,10 +594,11 @@ def core_api_download_scenario(is_authenticated):
             action="Hazard Analysis - Scenarios Download",
             content_type="application/zip",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )

--- a/apis/intermediate_api/intermediate_api/api/core_api.py
+++ b/apis/intermediate_api/intermediate_api/api/core_api.py
@@ -27,16 +27,14 @@ CORE_API_TOKEN = "Bearer {}".format(
 def get_ensemble_ids(is_authenticated):
     if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
-            request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+            request,
+            const.ENSEMBLE_IDS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_IMS_ENDPOINT, methods=["GET"])
@@ -44,16 +42,14 @@ def get_ensemble_ids(is_authenticated):
 def get_im_ids(is_authenticated):
     if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
-            request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+            request,
+            const.ENSEMBLE_IMS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_CONTEXT_MAP_ENDPOINT, methods=["GET"])
@@ -68,13 +64,7 @@ def get_context_map(is_authenticated):
             CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_VS30_MAP_ENDPOINT, methods=["GET"])
@@ -82,16 +72,14 @@ def get_context_map(is_authenticated):
 def get_vs30_map(is_authenticated):
     if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
-            request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+            request,
+            const.SITE_VS30_MAP_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_VS30_SOIL_CLASS_ENDPOINT, methods=["GET"])
@@ -106,13 +94,7 @@ def get_soil_class_from_vs30(is_authenticated):
             CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_STATION_ENDPOINT, methods=["GET"])
@@ -129,13 +111,7 @@ def get_station(is_authenticated):
             action="Hazard Analysis - Set Station",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 # Seismic Hazard
@@ -153,13 +129,7 @@ def get_hazard(is_authenticated):
             action="Hazard Analysis - Hazard Curve Compute",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_ENDPOINT, methods=["GET"])
@@ -176,13 +146,7 @@ def get_hazard_nzs1170p5(is_authenticated):
             action="Hazard Analysis - Hazard NZS1170p5 Compute",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_SOIL_CLASS_ENDPOINT, methods=["GET"])
@@ -190,16 +154,14 @@ def get_hazard_nzs1170p5(is_authenticated):
 def get_nzs1170p5_soil_class(is_authenticated):
     if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
-            request, const.NZS1170p5_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
+            request,
+            const.NZS1170p5_SOIL_CLASS,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
@@ -214,13 +176,7 @@ def get_nzs1170p5_default_params(is_authenticated):
             CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_ENDPOINT, methods=["GET"])
@@ -237,13 +193,7 @@ def get_hazard_nzta(is_authenticated):
             action="Hazard Analysis - Hazard NZTA Compute",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_SOIL_CLASS_ENDPOINT, methods=["GET"])
@@ -251,16 +201,14 @@ def get_hazard_nzta(is_authenticated):
 def get_nzta_soil_class(is_authenticated):
     if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
-            request, const.NZTA_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
+            request,
+            const.NZTA_SOIL_CLASS,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
@@ -275,13 +223,7 @@ def get_nzta_default_params(is_authenticated):
             CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
@@ -298,13 +240,7 @@ def get_disagg(is_authenticated):
             action="Hazard Analysis - Disaggregation Compute",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
@@ -321,13 +257,7 @@ def get_uhs(is_authenticated):
             action="Hazard Analysis - UHS Compute",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_UHS_NZS1170P5_ENDPOINT, methods=["GET"])
@@ -344,13 +274,7 @@ def get_uhs_nzs1170p5(is_authenticated):
             action="Hazard Analysis - UHS NZS1170p5 Compute",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 # GMS
@@ -369,13 +293,7 @@ def compute_ensemble_gms(is_authenticated):
             action="Hazard Analysis - GMS Compute",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_IM_WEIGHTS_ENDPOINT, methods=["GET"])
@@ -390,13 +308,7 @@ def get_default_im_weights(is_authenticated):
             CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
@@ -411,13 +323,7 @@ def get_default_causal_params(is_authenticated):
             CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_GMS_DATASETS_ENDPOINT, methods=["GET"])
@@ -432,13 +338,7 @@ def get_gm_datasets(is_authenticated):
             CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_GMS_IMS_ENDPOINT_ENDPOINT, methods=["GET"])
@@ -446,16 +346,14 @@ def get_gm_datasets(is_authenticated):
 def get_gms_available_ims(is_authenticated):
     if is_authenticated and auth0.requires_permission("hazard:gms"):
         return utils.proxy_to_api(
-            request, const.GMS_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+            request,
+            const.GMS_IMS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 # Scenarios
@@ -473,13 +371,7 @@ def get_scenario(is_authenticated):
             action="Hazard Analysis - Scenarios Get",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 # Download
@@ -499,13 +391,7 @@ def core_api_download_hazard(is_authenticated):
             content_type="application/zip",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_DOWNLOAD_ENDPOINT, methods=["GET"])
@@ -523,13 +409,7 @@ def core_api_download_disagg(is_authenticated):
             content_type="application/zip",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_UHS_DOWNLOAD_ENDPOINT, methods=["GET"])
@@ -547,13 +427,7 @@ def core_api_download_uhs(is_authenticated):
             content_type="application/zip",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(f"{const.CORE_API_GMS_DOWNLOAD_ENDPOINT}/<token>", methods=["GET"])
@@ -571,13 +445,7 @@ def core_api_download_gms(is_authenticated, token):
             content_type="application/zip",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(f"{const.CORE_API_SCENARIOS_DOWNLOAD_ENDPOINT}", methods=["GET"])
@@ -595,10 +463,4 @@ def core_api_download_scenario(is_authenticated):
             content_type="application/zip",
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()

--- a/apis/intermediate_api/intermediate_api/api/core_api.py
+++ b/apis/intermediate_api/intermediate_api/api/core_api.py
@@ -23,7 +23,7 @@ CORE_API_TOKEN = "Bearer {}".format(
 
 # Site Selection
 @app.route(const.CORE_API_ENSEMBLE_IDS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_ensemble_ids(is_authenticated):
     return utils.proxy_to_api(
         request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
@@ -31,7 +31,7 @@ def get_ensemble_ids(is_authenticated):
 
 
 @app.route(const.CORE_API_IMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_im_ids(is_authenticated):
     return utils.proxy_to_api(
         request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
@@ -39,7 +39,7 @@ def get_im_ids(is_authenticated):
 
 
 @app.route(const.CORE_API_CONTEXT_MAP_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_context_map(is_authenticated):
     return utils.proxy_to_api(
         request, const.SITE_CONTEXT_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
@@ -47,7 +47,7 @@ def get_context_map(is_authenticated):
 
 
 @app.route(const.CORE_API_VS30_MAP_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_vs30_map(is_authenticated):
     return utils.proxy_to_api(
         request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
@@ -55,7 +55,7 @@ def get_vs30_map(is_authenticated):
 
 
 @app.route(const.CORE_API_VS30_SOIL_CLASS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_soil_class_from_vs30(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -67,7 +67,7 @@ def get_soil_class_from_vs30(is_authenticated):
 
 
 @app.route(const.CORE_API_STATION_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_station(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -82,7 +82,7 @@ def get_station(is_authenticated):
 
 # Seismic Hazard
 @app.route(const.CORE_API_HAZARD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_hazard(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -104,7 +104,7 @@ def get_hazard(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_hazard_nzs1170p5(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -126,7 +126,7 @@ def get_hazard_nzs1170p5(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_SOIL_CLASS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_nzs1170p5_soil_class(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -142,7 +142,7 @@ def get_nzs1170p5_soil_class(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_nzs1170p5_default_params(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -162,7 +162,7 @@ def get_nzs1170p5_default_params(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_hazard_nzta(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -184,7 +184,7 @@ def get_hazard_nzta(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_SOIL_CLASS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_nzta_soil_class(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -200,7 +200,7 @@ def get_nzta_soil_class(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_nzta_default_params(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -220,7 +220,7 @@ def get_nzta_default_params(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_disagg(is_authenticated):
     if auth0.requires_permission("hazard:disagg"):
         return utils.proxy_to_api(
@@ -242,7 +242,7 @@ def get_disagg(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_uhs(is_authenticated):
     if auth0.requires_permission("hazard:uhs"):
         return utils.proxy_to_api(
@@ -264,7 +264,7 @@ def get_uhs(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_UHS_NZS1170P5_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_uhs_nzs1170p5(is_authenticated):
     if auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
@@ -287,7 +287,7 @@ def get_uhs_nzs1170p5(is_authenticated):
 
 # GMS
 @app.route(const.CORE_API_GMS_ENDPOINT, methods=["POST"])
-@decorators.requires_auth
+@decorators.get_authentication
 def compute_ensemble_gms(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -302,7 +302,7 @@ def compute_ensemble_gms(is_authenticated):
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_IM_WEIGHTS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_default_im_weights(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -314,7 +314,7 @@ def get_default_im_weights(is_authenticated):
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_default_causal_params(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -327,7 +327,7 @@ def get_default_causal_params(is_authenticated):
 
 # GMS
 @app.route(const.CORE_API_GMS_DATASETS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_gm_datasets(is_authenticated):
     return utils.proxy_to_api(
         request, const.GMS_GM_DATASETS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
@@ -335,7 +335,7 @@ def get_gm_datasets(is_authenticated):
 
 
 @app.route(const.CORE_API_GMS_IMS_ENDPOINT_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_gms_available_ims(is_authenticated):
     return utils.proxy_to_api(
         request, const.GMS_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
@@ -344,7 +344,7 @@ def get_gms_available_ims(is_authenticated):
 
 # Scenarios
 @app.route(const.CORE_API_SCENARIOS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_scenario(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -360,7 +360,7 @@ def get_scenario(is_authenticated):
 # Download
 # CORE API
 @app.route(const.CORE_API_HAZARD_CURVE_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def core_api_download_hazard(is_authenticated):
     core_response = utils.proxy_to_api(
         request,
@@ -377,7 +377,7 @@ def core_api_download_hazard(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def core_api_download_disagg(is_authenticated):
     core_response = utils.proxy_to_api(
         request,
@@ -394,7 +394,7 @@ def core_api_download_disagg(is_authenticated):
 
 
 @app.route(const.CORE_API_HAZARD_UHS_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def core_api_download_uhs(is_authenticated):
     core_response = utils.proxy_to_api(
         request,
@@ -411,7 +411,7 @@ def core_api_download_uhs(is_authenticated):
 
 
 @app.route(f"{const.CORE_API_GMS_DOWNLOAD_ENDPOINT}/<token>", methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def core_api_download_gms(is_authenticated, token):
     core_response = utils.proxy_to_api(
         request,
@@ -428,7 +428,7 @@ def core_api_download_gms(is_authenticated, token):
 
 
 @app.route(f"{const.CORE_API_SCENARIOS_DOWNLOAD_ENDPOINT}", methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def core_api_download_scenario(is_authenticated):
     core_response = utils.proxy_to_api(
         request,

--- a/apis/intermediate_api/intermediate_api/api/core_api.py
+++ b/apis/intermediate_api/intermediate_api/api/core_api.py
@@ -25,58 +25,110 @@ CORE_API_TOKEN = "Bearer {}".format(
 @app.route(const.CORE_API_ENSEMBLE_IDS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_ensemble_ids(is_authenticated):
-    return utils.proxy_to_api(
-        request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_IMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_im_ids(is_authenticated):
-    return utils.proxy_to_api(
-        request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_CONTEXT_MAP_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_context_map(is_authenticated):
-    return utils.proxy_to_api(
-        request, const.SITE_CONTEXT_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.SITE_CONTEXT_MAP_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_VS30_MAP_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_vs30_map(is_authenticated):
-    return utils.proxy_to_api(
-        request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_VS30_SOIL_CLASS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_soil_class_from_vs30(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.SITE_VS30_SOIL_CLASS_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.SITE_VS30_SOIL_CLASS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_STATION_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_station(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.SITE_LOCATION_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Set Station",
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.SITE_LOCATION_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Set Station",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -84,7 +136,7 @@ def get_station(is_authenticated):
 @app.route(const.CORE_API_HAZARD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_hazard(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.ENSEMBLE_HAZARD_ENDPOINT,
@@ -106,7 +158,7 @@ def get_hazard(is_authenticated):
 @app.route(const.CORE_API_HAZARD_NZS1170P5_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_hazard_nzs1170p5(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZS1170p5_HAZARD_ENDPOINT,
@@ -128,7 +180,7 @@ def get_hazard_nzs1170p5(is_authenticated):
 @app.route(const.CORE_API_HAZARD_NZS1170P5_SOIL_CLASS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_nzs1170p5_soil_class(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request, const.NZS1170p5_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
@@ -144,7 +196,7 @@ def get_nzs1170p5_soil_class(is_authenticated):
 @app.route(const.CORE_API_HAZARD_NZS1170P5_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_nzs1170p5_default_params(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZS1170p5_DEFAULT_PARAMS_ENDPOINT,
@@ -164,7 +216,7 @@ def get_nzs1170p5_default_params(is_authenticated):
 @app.route(const.CORE_API_HAZARD_NZTA_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_hazard_nzta(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZTA_HAZARD_ENDPOINT,
@@ -186,7 +238,7 @@ def get_hazard_nzta(is_authenticated):
 @app.route(const.CORE_API_HAZARD_NZTA_SOIL_CLASS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_nzta_soil_class(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request, const.NZTA_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
@@ -202,7 +254,7 @@ def get_nzta_soil_class(is_authenticated):
 @app.route(const.CORE_API_HAZARD_NZTA_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_nzta_default_params(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZTA_DEFAULT_PARAMS_ENDPOINT,
@@ -222,7 +274,7 @@ def get_nzta_default_params(is_authenticated):
 @app.route(const.CORE_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_disagg(is_authenticated):
-    if auth0.requires_permission("hazard:disagg"):
+    if is_authenticated and auth0.requires_permission("hazard:disagg"):
         return utils.proxy_to_api(
             request,
             const.ENSEMBLE_DISAGG_ENDPOINT,
@@ -244,7 +296,7 @@ def get_disagg(is_authenticated):
 @app.route(const.CORE_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_uhs(is_authenticated):
-    if auth0.requires_permission("hazard:uhs"):
+    if is_authenticated and auth0.requires_permission("hazard:uhs"):
         return utils.proxy_to_api(
             request,
             const.ENSEMBLE_UHS_ENDPOINT,
@@ -266,7 +318,7 @@ def get_uhs(is_authenticated):
 @app.route(const.CORE_API_HAZARD_UHS_NZS1170P5_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_uhs_nzs1170p5(is_authenticated):
-    if auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZS1170p5_UHS_ENDPOINT,
@@ -289,56 +341,99 @@ def get_uhs_nzs1170p5(is_authenticated):
 @app.route(const.CORE_API_GMS_ENDPOINT, methods=["POST"])
 @decorators.get_authentication
 def compute_ensemble_gms(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_GMS_COMPUTE_ENDPOINT,
-        "POST",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        data=request.data.decode(),
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - GMS Compute",
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_GMS_COMPUTE_ENDPOINT,
+            "POST",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            data=request.data.decode(),
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - GMS Compute",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_IM_WEIGHTS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_default_im_weights(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.GMS_DEFAULT_IM_WEIGHTS_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.GMS_DEFAULT_IM_WEIGHTS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_default_causal_params(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
-# GMS
 @app.route(const.CORE_API_GMS_DATASETS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_gm_datasets(is_authenticated):
-    return utils.proxy_to_api(
-        request, const.GMS_GM_DATASETS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.GMS_GM_DATASETS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.CORE_API_GMS_IMS_ENDPOINT_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_gms_available_ims(is_authenticated):
-    return utils.proxy_to_api(
-        request, const.GMS_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request, const.GMS_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -346,14 +441,22 @@ def get_gms_available_ims(is_authenticated):
 @app.route(const.CORE_API_SCENARIOS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_scenario(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_SCENARIO_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Scenarios Get",
+    if is_authenticated and auth0.requires_permission("hazard:scenarios"):
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_SCENARIO_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Scenarios Get",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -362,83 +465,113 @@ def get_scenario(is_authenticated):
 @app.route(const.CORE_API_HAZARD_CURVE_DOWNLOAD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def core_api_download_hazard(is_authenticated):
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_HAZARD_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Hazard Download",
-        content_type="application/zip",
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_HAZARD_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Hazard Download",
+            content_type="application/zip",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
-
-    return core_response
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_DOWNLOAD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def core_api_download_disagg(is_authenticated):
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_DISAGG_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Disaggregation Download",
-        content_type="application/zip",
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_DISAGG_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Disaggregation Download",
+            content_type="application/zip",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
-
-    return core_response
 
 
 @app.route(const.CORE_API_HAZARD_UHS_DOWNLOAD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def core_api_download_uhs(is_authenticated):
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_UHS_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - UHS Download",
-        content_type="application/zip",
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_UHS_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - UHS Download",
+            content_type="application/zip",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
-
-    return core_response
 
 
 @app.route(f"{const.CORE_API_GMS_DOWNLOAD_ENDPOINT}/<token>", methods=["GET"])
 @decorators.get_authentication
 def core_api_download_gms(is_authenticated, token):
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_GMS_DOWNLOAD_ENDPOINT + "/" + token,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - GMS Download",
-        content_type="application/zip",
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_GMS_DOWNLOAD_ENDPOINT + "/" + token,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - GMS Download",
+            content_type="application/zip",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
-
-    return core_response
 
 
 @app.route(f"{const.CORE_API_SCENARIOS_DOWNLOAD_ENDPOINT}", methods=["GET"])
 @decorators.get_authentication
 def core_api_download_scenario(is_authenticated):
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_SCENARIO_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Scenarios Download",
-        content_type="application/zip",
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_SCENARIO_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Scenarios Download",
+            content_type="application/zip",
+        )
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
-
-    return core_response

--- a/apis/intermediate_api/intermediate_api/api/core_api.py
+++ b/apis/intermediate_api/intermediate_api/api/core_api.py
@@ -25,7 +25,7 @@ CORE_API_TOKEN = "Bearer {}".format(
 @app.route(const.CORE_API_ENSEMBLE_IDS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_ensemble_ids(is_authenticated):
-    if is_authenticated:
+    if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
             request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
@@ -42,7 +42,7 @@ def get_ensemble_ids(is_authenticated):
 @app.route(const.CORE_API_IMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_im_ids(is_authenticated):
-    if is_authenticated:
+    if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
             request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
@@ -59,7 +59,7 @@ def get_im_ids(is_authenticated):
 @app.route(const.CORE_API_CONTEXT_MAP_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_context_map(is_authenticated):
-    if is_authenticated:
+    if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
             request,
             const.SITE_CONTEXT_MAP_ENDPOINT,
@@ -80,7 +80,7 @@ def get_context_map(is_authenticated):
 @app.route(const.CORE_API_VS30_MAP_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_vs30_map(is_authenticated):
-    if is_authenticated:
+    if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
             request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
@@ -97,7 +97,7 @@ def get_vs30_map(is_authenticated):
 @app.route(const.CORE_API_VS30_SOIL_CLASS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_soil_class_from_vs30(is_authenticated):
-    if is_authenticated:
+    if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
             request,
             const.SITE_VS30_SOIL_CLASS_ENDPOINT,
@@ -118,7 +118,7 @@ def get_soil_class_from_vs30(is_authenticated):
 @app.route(const.CORE_API_STATION_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_station(is_authenticated):
-    if is_authenticated:
+    if is_authenticated and auth0.requires_permission("hazard"):
         return utils.proxy_to_api(
             request,
             const.SITE_LOCATION_ENDPOINT,
@@ -333,7 +333,7 @@ def get_uhs(is_authenticated):
 @app.route(const.CORE_API_HAZARD_UHS_NZS1170P5_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_uhs_nzs1170p5(is_authenticated):
-    if is_authenticated and auth0.requires_permission("hazard:hazard"):
+    if is_authenticated and auth0.requires_permission("hazard:uhs"):
         return utils.proxy_to_api(
             request,
             const.NZS1170p5_UHS_ENDPOINT,

--- a/apis/intermediate_api/intermediate_api/api/intermediate_api.py
+++ b/apis/intermediate_api/intermediate_api/api/intermediate_api.py
@@ -37,13 +37,7 @@ def get_auth0_user_key_info(is_authenticated):
 
         return jsonify({"permissions": permission_list, "id": user_id})
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 # Edit User
@@ -64,13 +58,7 @@ def get_auth0_users(is_authenticated):
         response, status_code = auth0.get_users()
         return jsonify(response), status_code
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PRIVATE_PROJECTS_ENDPOINT, methods=["GET"])
@@ -84,13 +72,7 @@ def get_private_projects(is_authenticated):
         )
         return jsonify(db.get_projects("private"))
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PUBLIC_PROJECTS_ENDPOINT, methods=["GET"])
@@ -104,13 +86,7 @@ def get_public_projects(is_authenticated):
         )
         return jsonify(db.get_projects("public"))
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_USER_PROJECTS_ENDPOINT, methods=["GET"])
@@ -129,13 +105,7 @@ def get_user_allowed_projects(is_authenticated):
 
         return jsonify(db.get_user_project_permission(user_id))
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_USER_ALLOCATE_PROJECTS_ENDPOINT, methods=["POST"])
@@ -157,13 +127,7 @@ def allocate_projects_to_user(is_authenticated):
 
         return Response(status=const.OK_CODE)
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_USER_REMOVE_PROJECTS_ENDPOINT, methods=["POST"])
@@ -185,13 +149,7 @@ def remove_projects_from_user(is_authenticated):
 
         return Response(status=const.OK_CODE)
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_ALL_USERS_PROJECTS_ENDPOINT, methods=["GET"])
@@ -206,13 +164,7 @@ def get_all_users_projects(is_authenticated):
         auth0_users, _ = auth0.get_users()
         return db.get_all_users_project_permissions(auth0_users)
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PERMISSIONS_ENDPOINT, methods=["GET"])
@@ -226,13 +178,7 @@ def get_all_permissions(is_authenticated):
         )
         return jsonify({"all_permissions": db.get_all_permissions_for_dashboard()})
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_ALL_USERS_PERMISSIONS_ENDPOINT, methods=["GET"])
@@ -247,13 +193,7 @@ def get_all_users_permissions(is_authenticated):
         auth0_users, _ = auth0.get_users()
         return db.get_all_users_permissions(auth0_users)
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.INTERMEDIATE_API_CREATE_PROJECT_ENDPOINT, methods=["POST"])
@@ -299,10 +239,4 @@ def create_project(is_authenticated):
                     response_code,
                 )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()

--- a/apis/intermediate_api/intermediate_api/api/intermediate_api.py
+++ b/apis/intermediate_api/intermediate_api/api/intermediate_api.py
@@ -37,9 +37,12 @@ def get_auth0_user_key_info(is_authenticated):
 
         return jsonify({"permissions": permission_list, "id": user_id})
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -54,16 +57,19 @@ def get_auth0_users(is_authenticated):
     setting user permission to users that don't
     exist in the DB yet
     """
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_AUTH0_USERS_ENDPOINT}"
         )
         response, status_code = auth0.get_users()
         return jsonify(response), status_code
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -72,26 +78,39 @@ def get_auth0_users(is_authenticated):
 @decorators.endpoint_exception_handler
 def get_private_projects(is_authenticated):
     """Fetching all private projects from the Project table"""
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_ALL_PRIVATE_PROJECTS_ENDPOINT}"
         )
         return jsonify(db.get_projects("private"))
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PUBLIC_PROJECTS_ENDPOINT, methods=["GET"])
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
-def get_public_projects():
+def get_public_projects(is_authenticated):
     """Fetching all public projects from the Project table"""
-    app.logger.info(
-        f"Received request at {const.INTERMEDIATE_API_ALL_PUBLIC_PROJECTS_ENDPOINT}"
+    if is_authenticated and auth0.is_admin():
+        app.logger.info(
+            f"Received request at {const.INTERMEDIATE_API_ALL_PUBLIC_PROJECTS_ENDPOINT}"
+        )
+        return jsonify(db.get_projects("public"))
+
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
-    return jsonify(db.get_projects("public"))
 
 
 @app.route(const.INTERMEDIATE_API_USER_PROJECTS_ENDPOINT, methods=["GET"])
@@ -101,7 +120,7 @@ def get_user_allowed_projects(is_authenticated):
     """Fetching all the projects that are already allowed to a user
     Will be used for allowed Private Projects dropdown
     """
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_USER_PROJECTS_ENDPOINT}"
         )
@@ -110,9 +129,12 @@ def get_user_allowed_projects(is_authenticated):
 
         return jsonify(db.get_user_project_permission(user_id))
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -121,7 +143,7 @@ def get_user_allowed_projects(is_authenticated):
 @decorators.endpoint_exception_handler
 def allocate_projects_to_user(is_authenticated):
     """Allocate the chosen project(s) to the chosen user."""
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_USER_ALLOCATE_PROJECTS_ENDPOINT}"
         )
@@ -135,9 +157,12 @@ def allocate_projects_to_user(is_authenticated):
 
         return Response(status=const.OK_CODE)
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -146,7 +171,7 @@ def allocate_projects_to_user(is_authenticated):
 @decorators.endpoint_exception_handler
 def remove_projects_from_user(is_authenticated):
     """Remove the chosen project(s) from the chosen user."""
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_USER_REMOVE_PROJECTS_ENDPOINT}"
         )
@@ -160,9 +185,12 @@ def remove_projects_from_user(is_authenticated):
 
         return Response(status=const.OK_CODE)
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -171,16 +199,19 @@ def remove_projects_from_user(is_authenticated):
 @decorators.endpoint_exception_handler
 def get_all_users_projects(is_authenticated):
     """Pull every assigned project for all users from Users_Projects table"""
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_ALL_USERS_PROJECTS_ENDPOINT}"
         )
         auth0_users, _ = auth0.get_users()
         return db.get_all_users_project_permissions(auth0_users)
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -189,15 +220,18 @@ def get_all_users_projects(is_authenticated):
 @decorators.endpoint_exception_handler
 def get_all_permissions(is_authenticated):
     """Pull all possible access permission (Auth0_Permission table)"""
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_ALL_PERMISSIONS_ENDPOINT}"
         )
         return jsonify({"all_permissions": db.get_all_permissions_for_dashboard()})
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -206,16 +240,19 @@ def get_all_permissions(is_authenticated):
 @decorators.endpoint_exception_handler
 def get_all_users_permissions(is_authenticated):
     """Pull every assigned access permission for all uesrs from Users_Permissions table"""
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_ALL_USERS_PERMISSIONS_ENDPOINT}"
         )
         auth0_users, _ = auth0.get_users()
         return db.get_all_users_permissions(auth0_users)
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )
 
 
@@ -224,7 +261,7 @@ def get_all_users_permissions(is_authenticated):
 @decorators.endpoint_exception_handler
 def create_project(is_authenticated):
     """Create new project(s)"""
-    if is_authenticated:
+    if is_authenticated and auth0.is_admin():
         app.logger.info(
             f"Received request at {const.INTERMEDIATE_API_CREATE_PROJECT_ENDPOINT}"
         )
@@ -262,7 +299,10 @@ def create_project(is_authenticated):
                     response_code,
                 )
 
-    return (
-        jsonify({"Warning": "You do not have permission to access."}),
-        const.UNAUTHORIZED_CODE,
+    raise auth0.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "You don't have access to this resource",
+        },
+        const.NO_ACCESS_RIGHT_CODE,
     )

--- a/apis/intermediate_api/intermediate_api/api/intermediate_api.py
+++ b/apis/intermediate_api/intermediate_api/api/intermediate_api.py
@@ -12,7 +12,7 @@ import intermediate_api.constants as const
 
 
 @app.route(const.INTERMEDIATE_API_AUTH0_USER_INFO_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def get_auth0_user_key_info(is_authenticated):
     """Getting users permission on their first launch
@@ -45,7 +45,7 @@ def get_auth0_user_key_info(is_authenticated):
 
 # Edit User
 @app.route(const.INTERMEDIATE_API_AUTH0_USERS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_auth0_users(is_authenticated):
     """Fetching all the existing users from the Auth0
     These will be used for User dropdown in the Permission Config
@@ -68,7 +68,7 @@ def get_auth0_users(is_authenticated):
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PRIVATE_PROJECTS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def get_private_projects(is_authenticated):
     """Fetching all private projects from the Project table"""
@@ -95,7 +95,7 @@ def get_public_projects():
 
 
 @app.route(const.INTERMEDIATE_API_USER_PROJECTS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def get_user_allowed_projects(is_authenticated):
     """Fetching all the projects that are already allowed to a user
@@ -117,7 +117,7 @@ def get_user_allowed_projects(is_authenticated):
 
 
 @app.route(const.INTERMEDIATE_API_USER_ALLOCATE_PROJECTS_ENDPOINT, methods=["POST"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def allocate_projects_to_user(is_authenticated):
     """Allocate the chosen project(s) to the chosen user."""
@@ -142,7 +142,7 @@ def allocate_projects_to_user(is_authenticated):
 
 
 @app.route(const.INTERMEDIATE_API_USER_REMOVE_PROJECTS_ENDPOINT, methods=["POST"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def remove_projects_from_user(is_authenticated):
     """Remove the chosen project(s) from the chosen user."""
@@ -167,7 +167,7 @@ def remove_projects_from_user(is_authenticated):
 
 
 @app.route(const.INTERMEDIATE_API_ALL_USERS_PROJECTS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def get_all_users_projects(is_authenticated):
     """Pull every assigned project for all users from Users_Projects table"""
@@ -185,7 +185,7 @@ def get_all_users_projects(is_authenticated):
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PERMISSIONS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def get_all_permissions(is_authenticated):
     """Pull all possible access permission (Auth0_Permission table)"""
@@ -202,7 +202,7 @@ def get_all_permissions(is_authenticated):
 
 
 @app.route(const.INTERMEDIATE_API_ALL_USERS_PERMISSIONS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def get_all_users_permissions(is_authenticated):
     """Pull every assigned access permission for all uesrs from Users_Permissions table"""
@@ -220,7 +220,7 @@ def get_all_users_permissions(is_authenticated):
 
 
 @app.route(const.INTERMEDIATE_API_CREATE_PROJECT_ENDPOINT, methods=["POST"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def create_project(is_authenticated):
     """Create new project(s)"""

--- a/apis/intermediate_api/intermediate_api/api/intermediate_api.py
+++ b/apis/intermediate_api/intermediate_api/api/intermediate_api.py
@@ -36,14 +36,14 @@ def get_auth0_user_key_info(is_authenticated):
         db.update_user_access_permission(user_id, permission_list)
 
         return jsonify({"permissions": permission_list, "id": user_id})
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 # Edit User
@@ -63,14 +63,14 @@ def get_auth0_users(is_authenticated):
         )
         response, status_code = auth0.get_users()
         return jsonify(response), status_code
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PRIVATE_PROJECTS_ENDPOINT, methods=["GET"])
@@ -83,14 +83,14 @@ def get_private_projects(is_authenticated):
             f"Received request at {const.INTERMEDIATE_API_ALL_PRIVATE_PROJECTS_ENDPOINT}"
         )
         return jsonify(db.get_projects("private"))
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PUBLIC_PROJECTS_ENDPOINT, methods=["GET"])
@@ -103,14 +103,14 @@ def get_public_projects(is_authenticated):
             f"Received request at {const.INTERMEDIATE_API_ALL_PUBLIC_PROJECTS_ENDPOINT}"
         )
         return jsonify(db.get_projects("public"))
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_USER_PROJECTS_ENDPOINT, methods=["GET"])
@@ -128,14 +128,14 @@ def get_user_allowed_projects(is_authenticated):
         user_id = request.args.to_dict()["user_id"]
 
         return jsonify(db.get_user_project_permission(user_id))
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_USER_ALLOCATE_PROJECTS_ENDPOINT, methods=["POST"])
@@ -156,14 +156,14 @@ def allocate_projects_to_user(is_authenticated):
         db.allocate_projects_to_user(user_id, project_list)
 
         return Response(status=const.OK_CODE)
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_USER_REMOVE_PROJECTS_ENDPOINT, methods=["POST"])
@@ -184,14 +184,14 @@ def remove_projects_from_user(is_authenticated):
         db.remove_projects_from_user(user_id, project_list)
 
         return Response(status=const.OK_CODE)
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_ALL_USERS_PROJECTS_ENDPOINT, methods=["GET"])
@@ -205,14 +205,14 @@ def get_all_users_projects(is_authenticated):
         )
         auth0_users, _ = auth0.get_users()
         return db.get_all_users_project_permissions(auth0_users)
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_ALL_PERMISSIONS_ENDPOINT, methods=["GET"])
@@ -225,14 +225,14 @@ def get_all_permissions(is_authenticated):
             f"Received request at {const.INTERMEDIATE_API_ALL_PERMISSIONS_ENDPOINT}"
         )
         return jsonify({"all_permissions": db.get_all_permissions_for_dashboard()})
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_ALL_USERS_PERMISSIONS_ENDPOINT, methods=["GET"])
@@ -246,14 +246,14 @@ def get_all_users_permissions(is_authenticated):
         )
         auth0_users, _ = auth0.get_users()
         return db.get_all_users_permissions(auth0_users)
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.INTERMEDIATE_API_CREATE_PROJECT_ENDPOINT, methods=["POST"])
@@ -298,11 +298,11 @@ def create_project(is_authenticated):
                     jsonify({"project_created": False}),
                     response_code,
                 )
-
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )

--- a/apis/intermediate_api/intermediate_api/api/project_api.py
+++ b/apis/intermediate_api/intermediate_api/api/project_api.py
@@ -17,7 +17,7 @@ def get_available_projects():
 
 
 @app.route(const.PROJECT_API_PROJECT_IDS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 @decorators.endpoint_exception_handler
 def get_available_project_ids(is_authenticated):
     if is_authenticated:
@@ -34,7 +34,7 @@ def get_available_project_ids(is_authenticated):
 
 
 @app.route(const.PROJECT_API_SITES_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_sites(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -46,7 +46,7 @@ def get_project_sites(is_authenticated):
 
 
 @app.route(const.PROJECT_API_IMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_ims(is_authenticated):
     return utils.proxy_to_api(
         request, const.PROJECT_IMS_ENDPOINT, "GET", PROJECT_API_BASE, PROJECT_API_TOKEN,
@@ -54,7 +54,7 @@ def get_project_ims(is_authenticated):
 
 
 @app.route(const.PROJECT_API_MAPS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_maps(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -69,7 +69,7 @@ def get_project_maps(is_authenticated):
 
 # Seismic Hazard
 @app.route(const.PROJECT_API_HAZARD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_hazard(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -83,7 +83,7 @@ def get_project_hazard(is_authenticated):
 
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_disagg(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -97,7 +97,7 @@ def get_project_disagg(is_authenticated):
 
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_RPS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_disagg_rps(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -109,7 +109,7 @@ def get_project_disagg_rps(is_authenticated):
 
 
 @app.route(const.PROJECT_API_HAZARD_UHS_RPS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_uhs_rps(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -121,7 +121,7 @@ def get_project_uhs_rps(is_authenticated):
 
 
 @app.route(const.PROJECT_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_project_uhs(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -135,7 +135,7 @@ def get_project_uhs(is_authenticated):
 
 
 @app.route(const.PROJECT_API_GMS_RUNS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_gms_runs(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -147,7 +147,7 @@ def get_gms_runs(is_authenticated):
 
 
 @app.route(const.PROJECT_API_GMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_ensemble_gms(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -161,7 +161,7 @@ def get_ensemble_gms(is_authenticated):
 
 
 @app.route(const.PROJECT_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_gms_default_causal_params(is_authenticated):
     response = utils.proxy_to_api(
         request,
@@ -197,7 +197,7 @@ def get_gms_default_causal_params(is_authenticated):
 
 
 @app.route(const.PROJECT_API_SCENARIOS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def get_ensemble_scenarios(is_authenticated):
     return utils.proxy_to_api(
         request,
@@ -212,7 +212,7 @@ def get_ensemble_scenarios(is_authenticated):
 
 # PROJECT DOWNLOAD
 @app.route(const.PROJECT_API_HAZARD_CURVE_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def project_api_download_hazard(is_authenticated):
     project_response = utils.proxy_to_api(
         request,
@@ -229,7 +229,7 @@ def project_api_download_hazard(is_authenticated):
 
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def project_api_download_disagg(is_authenticated):
     project_response = utils.proxy_to_api(
         request,
@@ -246,7 +246,7 @@ def project_api_download_disagg(is_authenticated):
 
 
 @app.route(const.PROJECT_API_HAZARD_UHS_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def project_api_download_uhs(is_authenticated):
     project_response = utils.proxy_to_api(
         request,
@@ -263,7 +263,7 @@ def project_api_download_uhs(is_authenticated):
 
 
 @app.route(f"{const.PROJECT_API_GMS_DOWNLOAD_ENDPOINT}/<token>", methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def project_api_download_gms(is_authenticated, token):
     project_response = utils.proxy_to_api(
         request,
@@ -279,7 +279,7 @@ def project_api_download_gms(is_authenticated, token):
 
 
 @app.route(f"{const.PROJECT_API_SCENARIOS_DOWNLOAD_ENDPOINT}", methods=["GET"])
-@decorators.requires_auth
+@decorators.get_authentication
 def project_api_download_scenario(is_authenticated):
     project_response = utils.proxy_to_api(
         request,

--- a/apis/intermediate_api/intermediate_api/api/project_api.py
+++ b/apis/intermediate_api/intermediate_api/api/project_api.py
@@ -11,7 +11,7 @@ import intermediate_api.constants as const
 def has_project_permission(is_authenticated):
     """Check if the requested project id is valid.
     Those with authentication, check both private and public projects.
-    Those without authentication, check only the public projects.
+    Those without authentication, check public projects only.
 
     Parameters
     ----------

--- a/apis/intermediate_api/intermediate_api/api/project_api.py
+++ b/apis/intermediate_api/intermediate_api/api/project_api.py
@@ -92,13 +92,7 @@ def get_project_sites(*args, **kwargs):
             PROJECT_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_IMS_ENDPOINT, methods=["GET"])
@@ -115,13 +109,7 @@ def get_project_ims(*args, **kwargs):
             PROJECT_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_MAPS_ENDPOINT, methods=["GET"])
@@ -143,13 +131,7 @@ def get_project_maps(*args, **kwargs):
             action="Project - Site Selection Get" if is_authenticated else None,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 # Seismic Hazard
@@ -172,13 +154,7 @@ def get_project_hazard(*args, **kwargs):
             action="Project - Hazard Compute" if is_authenticated else None,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
@@ -200,13 +176,7 @@ def get_project_disagg(*args, **kwargs):
             action="Project - Disaggregation Compute" if is_authenticated else None,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_RPS_ENDPOINT, methods=["GET"])
@@ -223,13 +193,7 @@ def get_project_disagg_rps(*args, **kwargs):
             PROJECT_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_HAZARD_UHS_RPS_ENDPOINT, methods=["GET"])
@@ -246,13 +210,7 @@ def get_project_uhs_rps(*args, **kwargs):
             PROJECT_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
@@ -274,13 +232,7 @@ def get_project_uhs(*args, **kwargs):
             action="Project - UHS Compute" if is_authenticated else None,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_GMS_RUNS_ENDPOINT, methods=["GET"])
@@ -297,13 +249,7 @@ def get_gms_runs(*args, **kwargs):
             PROJECT_API_TOKEN,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_GMS_ENDPOINT, methods=["GET"])
@@ -325,13 +271,7 @@ def get_ensemble_gms(*args, **kwargs):
             action="Project - GMS Compute" if is_authenticated else None,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
@@ -378,13 +318,7 @@ def get_gms_default_causal_params(*args, **kwargs):
 
         return Response(status=response.status_code)
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 @app.route(const.PROJECT_API_SCENARIOS_ENDPOINT, methods=["GET"])
@@ -406,13 +340,7 @@ def get_ensemble_scenarios(*args, **kwargs):
             action="Project - Scenarios Get" if is_authenticated else None,
         )
     else:
-        raise auth0.AuthError(
-            {
-                "code": "Unauthorized",
-                "description": "You don't have access to this resource",
-            },
-            const.NO_ACCESS_RIGHT_CODE,
-        )
+        raise auth0.AuthError()
 
 
 # PROJECT DOWNLOAD

--- a/apis/intermediate_api/intermediate_api/api/project_api.py
+++ b/apis/intermediate_api/intermediate_api/api/project_api.py
@@ -6,7 +6,35 @@ import intermediate_api.utils as utils
 import intermediate_api.decorators as decorators
 import intermediate_api.auth0 as auth0
 import intermediate_api.constants as const
-import intermediate_api.api.intermediate_api as intermediate_api
+
+
+def has_project_permission(is_authenticated):
+    """Check if the requested project id is valid.
+    Those with authentication, check both private and public projects.
+    Those without authentication, check only the public projects.
+
+    Parameters
+    ----------
+    is_authenticated: bool
+    """
+    project_id = request.args.get("project_id")
+    if project_id is not None:
+        if is_authenticated:
+            user_id = auth0.get_user_id()
+            # Authenticated users can access to both private and public projects
+            allowed_projects = utils.run_project_crosscheck(
+                db.get_user_project_permission(user_id),
+                db.get_projects("public"),
+                get_available_projects()["ids"],
+            )
+            return True if project_id in allowed_projects else False
+        else:
+            public_projects = utils.run_project_crosscheck(
+                {}, db.get_projects("public"), get_available_projects()["ids"],
+            )
+            return True if project_id in public_projects else False
+    else:
+        return False
 
 
 # Site Selection
@@ -24,7 +52,7 @@ def get_available_project_ids(is_authenticated):
         user_id = auth0.get_user_id()
         return utils.run_project_crosscheck(
             db.get_user_project_permission(user_id),
-            intermediate_api.get_public_projects().get_json(),
+            db.get_projects("public"),
             get_available_projects()["ids"],
         )
     else:
@@ -36,185 +64,300 @@ def get_available_project_ids(is_authenticated):
 @app.route(const.PROJECT_API_SITES_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_sites(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_SITES_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_SITES_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_IMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_ims(is_authenticated):
-    return utils.proxy_to_api(
-        request, const.PROJECT_IMS_ENDPOINT, "GET", PROJECT_API_BASE, PROJECT_API_TOKEN,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_IMS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_MAPS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_maps(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_CONTEXT_MAPS_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id() if is_authenticated else None,
-        action="Project - Site Selection Get" if is_authenticated else None,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_CONTEXT_MAPS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+            user_id=auth0.get_user_id() if is_authenticated else None,
+            action="Project - Site Selection Get" if is_authenticated else None,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 # Seismic Hazard
 @app.route(const.PROJECT_API_HAZARD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_hazard(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_HAZARD_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id() if is_authenticated else None,
-        action="Project - Hazard Compute" if is_authenticated else None,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_HAZARD_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+            user_id=auth0.get_user_id() if is_authenticated else None,
+            action="Project - Hazard Compute" if is_authenticated else None,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_disagg(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_DISAGG_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id() if is_authenticated else None,
-        action="Project - Disaggregation Compute" if is_authenticated else None,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_DISAGG_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+            user_id=auth0.get_user_id() if is_authenticated else None,
+            action="Project - Disaggregation Compute" if is_authenticated else None,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_RPS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_disagg_rps(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_DISAGG_RPS_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_DISAGG_RPS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_HAZARD_UHS_RPS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_uhs_rps(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_UHS_RPS_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_UHS_RPS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_project_uhs(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_UHS_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id() if is_authenticated else None,
-        action="Project - UHS Compute" if is_authenticated else None,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_UHS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+            user_id=auth0.get_user_id() if is_authenticated else None,
+            action="Project - UHS Compute" if is_authenticated else None,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_GMS_RUNS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_gms_runs(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_GMS_RUNS_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_GMS_RUNS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_GMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_ensemble_gms(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_GMS_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id() if is_authenticated else None,
-        action="Project - GMS Compute" if is_authenticated else None,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_GMS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+            user_id=auth0.get_user_id() if is_authenticated else None,
+            action="Project - GMS Compute" if is_authenticated else None,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 @app.route(const.PROJECT_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_gms_default_causal_params(is_authenticated):
-    response = utils.proxy_to_api(
-        request,
-        const.PROJECT_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id() if is_authenticated else None,
-        action="Project - GMS Get Default Causal Params" if is_authenticated else None,
-    )
-
-    if response.status_code is const.OK_CODE:
-        data_dict = response.get_json()
-
-        contribution_df_data = data_dict["contribution_df"]
-
-        sorted_rrup, rrup_cdf = utils.calc_cdf(
-            contribution_df_data["contribution"][:], contribution_df_data["rrup"]
+    if has_project_permission(is_authenticated):
+        response = utils.proxy_to_api(
+            request,
+            const.PROJECT_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+            user_id=auth0.get_user_id() if is_authenticated else None,
+            action="Project - GMS Get Default Causal Params"
+            if is_authenticated
+            else None,
         )
-        sorted_mag, mag_cdf = utils.calc_cdf(
-            contribution_df_data["contribution"][:], contribution_df_data["magnitude"]
+
+        if response.status_code is const.OK_CODE:
+            data_dict = response.get_json()
+
+            contribution_df_data = data_dict["contribution_df"]
+
+            sorted_rrup, rrup_cdf = utils.calc_cdf(
+                contribution_df_data["contribution"][:], contribution_df_data["rrup"]
+            )
+            sorted_mag, mag_cdf = utils.calc_cdf(
+                contribution_df_data["contribution"][:],
+                contribution_df_data["magnitude"],
+            )
+            data_dict["contribution_df"] = {
+                "magnitude": sorted_mag.tolist(),
+                "mag_contribution": mag_cdf.tolist(),
+                "rrup": sorted_rrup.tolist(),
+                "rrup_contribution": rrup_cdf.tolist(),
+            }
+
+            return jsonify(data_dict)
+
+        return Response(status=response.status_code)
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
         )
-        data_dict["contribution_df"] = {
-            "magnitude": sorted_mag.tolist(),
-            "mag_contribution": mag_cdf.tolist(),
-            "rrup": sorted_rrup.tolist(),
-            "rrup_contribution": rrup_cdf.tolist(),
-        }
-
-        return jsonify(data_dict)
-
-    return Response(status=response.status_code)
 
 
 @app.route(const.PROJECT_API_SCENARIOS_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def get_ensemble_scenarios(is_authenticated):
-    return utils.proxy_to_api(
-        request,
-        const.PROJECT_SCENARIO_ENDPOINT,
-        "GET",
-        PROJECT_API_BASE,
-        PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id() if is_authenticated else None,
-        action="Project - Scenarios Get" if is_authenticated else None,
-    )
+    if has_project_permission(is_authenticated):
+        return utils.proxy_to_api(
+            request,
+            const.PROJECT_SCENARIO_ENDPOINT,
+            "GET",
+            PROJECT_API_BASE,
+            PROJECT_API_TOKEN,
+            user_id=auth0.get_user_id() if is_authenticated else None,
+            action="Project - Scenarios Get" if is_authenticated else None,
+        )
+    else:
+        raise auth0.AuthError(
+            {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            },
+            const.NO_ACCESS_RIGHT_CODE,
+        )
 
 
 # PROJECT DOWNLOAD
 @app.route(const.PROJECT_API_HAZARD_CURVE_DOWNLOAD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def project_api_download_hazard(is_authenticated):
-    project_response = utils.proxy_to_api(
+    return utils.proxy_to_api(
         request,
         const.PROJECT_HAZARD_DOWNLOAD_ENDPOINT,
         "GET",
@@ -225,13 +368,11 @@ def project_api_download_hazard(is_authenticated):
         content_type="application/zip",
     )
 
-    return project_response
-
 
 @app.route(const.PROJECT_API_HAZARD_DISAGG_DOWNLOAD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def project_api_download_disagg(is_authenticated):
-    project_response = utils.proxy_to_api(
+    return utils.proxy_to_api(
         request,
         const.PROJECT_DISAGG_DOWNLOAD_ENDPOINT,
         "GET",
@@ -242,13 +383,11 @@ def project_api_download_disagg(is_authenticated):
         content_type="application/zip",
     )
 
-    return project_response
-
 
 @app.route(const.PROJECT_API_HAZARD_UHS_DOWNLOAD_ENDPOINT, methods=["GET"])
 @decorators.get_authentication
 def project_api_download_uhs(is_authenticated):
-    project_response = utils.proxy_to_api(
+    return utils.proxy_to_api(
         request,
         const.PROJECT_UHS_DOWNLOAD_ENDPOINT,
         "GET",
@@ -259,13 +398,11 @@ def project_api_download_uhs(is_authenticated):
         content_type="application/zip",
     )
 
-    return project_response
-
 
 @app.route(f"{const.PROJECT_API_GMS_DOWNLOAD_ENDPOINT}/<token>", methods=["GET"])
 @decorators.get_authentication
 def project_api_download_gms(is_authenticated, token):
-    project_response = utils.proxy_to_api(
+    return utils.proxy_to_api(
         request,
         const.PROJECT_GMS_DOWNLOAD_ENDPOINT + "/" + token,
         PROJECT_API_BASE,
@@ -275,21 +412,17 @@ def project_api_download_gms(is_authenticated, token):
         content_type="application/zip",
     )
 
-    return project_response
-
 
 @app.route(f"{const.PROJECT_API_SCENARIOS_DOWNLOAD_ENDPOINT}", methods=["GET"])
 @decorators.get_authentication
 def project_api_download_scenario(is_authenticated):
-    project_response = utils.proxy_to_api(
+    return utils.proxy_to_api(
         request,
         const.PROJECT_SCENARIO_DOWNLOAD_ENDPOINT,
         "GET",
         PROJECT_API_BASE,
         PROJECT_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Project - Scenario Download",
+        user_id=auth0.get_user_id() if is_authenticated else None,
+        action="Project - Scenario Download" if is_authenticated else None,
         content_type="application/zip",
     )
-
-    return project_response

--- a/apis/intermediate_api/intermediate_api/auth0.py
+++ b/apis/intermediate_api/intermediate_api/auth0.py
@@ -20,9 +20,18 @@ AUTH0_DOMAIN = os.environ["AUTH0_DOMAIN"]
 
 
 class AuthError(Exception):
-    def __init__(self, error, status_code):
-        self.error = error
-        self.status_code = status_code
+    def __init__(self, error=None, status_code=None):
+        self.error = (
+            error
+            if error is not None
+            else {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            }
+        )
+        self.status_code = (
+            status_code if status_code is not None else const.NO_ACCESS_RIGHT_CODE
+        )
 
 
 @app.errorhandler(AuthError)

--- a/apis/intermediate_api/intermediate_api/auth0.py
+++ b/apis/intermediate_api/intermediate_api/auth0.py
@@ -163,3 +163,7 @@ def requires_permission(required_permission):
         return required_permission in token_permissions
 
     return False
+
+
+def is_admin():
+    return requires_permission("admin")

--- a/apis/intermediate_api/intermediate_api/create_db.py
+++ b/apis/intermediate_api/intermediate_api/create_db.py
@@ -21,7 +21,7 @@ PERMISSION_LIST = [
     "hazard:uhs",
     "hazard:gms",
     "project",
-    "psha-admin",
+    "admin",
 ]
 
 # Adding all users from Auth0 to the User table

--- a/apis/intermediate_api/intermediate_api/decorators.py
+++ b/apis/intermediate_api/intermediate_api/decorators.py
@@ -19,7 +19,7 @@ ALGORITHMS = os.environ["ALGORITHMS"]
 API_AUDIENCE = os.environ["API_AUDIENCE"]
 
 
-def requires_auth(f):
+def get_authentication(f):
     """Determines if the Access Token is valid"""
 
     @wraps(f)

--- a/apis/intermediate_api/intermediate_api/utils.py
+++ b/apis/intermediate_api/intermediate_api/utils.py
@@ -11,7 +11,6 @@ from slack_sdk.errors import SlackApiError
 from intermediate_api import app
 import intermediate_api.db as db
 import intermediate_api.decorators as decorators
-import intermediate_api.constants as const
 
 DOWNLOAD_URL_SECRET_KEY_CORE = os.environ["DOWNLOAD_URL_SECRET_KEY_CORE_API"]
 DOWNLOAD_URL_SECRET_KEY_PROJECT = os.environ["DOWNLOAD_URL_SECRET_KEY_PROJECT_API"]

--- a/apis/intermediate_api/setup.py
+++ b/apis/intermediate_api/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="intermediate_api",
-    version="20.8.1",
+    version="20.9.1",
     packages=find_packages(),
     url="https://github.com/ucgmsim/gmhazard",
     description="GMHazard Intermediate API",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,7 +57,7 @@ const App = () => {
 
                 <PrivateRoute
                   path="/permission-config"
-                  permission="psha-admin"
+                  permission="admin"
                   exact
                   component={PermissionConfig}
                 />

--- a/frontend/src/components/NavBar/LogoutButton.js
+++ b/frontend/src/components/NavBar/LogoutButton.js
@@ -52,7 +52,7 @@ const LogoutButton = () => {
           </DropdownItem>
         ) : null}
 
-        {hasPermission("psha-admin") ? (
+        {hasPermission("admin") ? (
           <DropdownItem
             tag={RouterNavLink}
             to="/permission-config"


### PR DESCRIPTION
# Permission check

- Bring back a single `proxy_to_api` function that only deals with forwarding requests to the right destination.
- Permission check is happening within the Intermediate API
    - Before proxy to Core/Project API
    - Every intermediate API calls except one call

## Core API
- Must be authenticated via Auth0
- Must have certain permission with Auth0 to use, such as
    - hazard - To be able to access to non-projects tab and Site Selection
    - hazard:hazard - To use Hazard Curve
    - hazard:disagg - To use Disaggregation

## Intermediate API
- Must be authenticated via Auth0
- Must have admin permission via Auth0
- One exception, `get_auth0_user_key_info()` this endpoint is for getting a user's information so whoever with Auth0 token will hit this endpoint right after they logged into the application.

## Project API
- May/May not be authenticated via Auth0
- If a user is authenticated via Auth0, they can access both Private and Public projects.
    - Check if the requested `project_id` is in the list of projects before forwarding it to the Project API.
    - The list of projects are
        - All Public projects
        - All Private projects that a user has permission with
- If a user is not authenticated via Auth0, they can only access Public projects.
    - Check if the requested `project_id` is in the list of public projects before forwarding it to the Project API.

![GMHazard_Updated_Authentication_structure drawio (1)](https://user-images.githubusercontent.com/7849113/141877540-0229d73b-50c6-4397-b4e5-2d64f4b83f27.png)


