### PR TITLE
Update Core API's Authentication structure

### DIFF
--- a/apis/intermediate_api/intermediate_api/api/core_api.py
+++ b/apis/intermediate_api/intermediate_api/api/core_api.py
@@ -23,68 +23,90 @@ CORE_API_TOKEN = "Bearer {}".format(
 
 # Site Selection
 @app.route(const.CORE_API_ENSEMBLE_IDS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_ensemble_ids():
-    return utils.proxy_to_api(
-        request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN
-    )
+@decorators.get_authentication
+def get_ensemble_ids(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard"):
+        return utils.proxy_to_api(
+            request, const.ENSEMBLE_IDS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_IMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_im_ids():
-    return utils.proxy_to_api(
-        request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN
-    )
+@decorators.get_authentication
+def get_im_ids(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard"):
+        return utils.proxy_to_api(
+            request, const.ENSEMBLE_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_CONTEXT_MAP_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_context_map():
-    return utils.proxy_to_api(
-        request, const.SITE_CONTEXT_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN
-    )
+@decorators.get_authentication
+def get_context_map(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard"):
+        return utils.proxy_to_api(
+            request,
+            const.SITE_CONTEXT_MAP_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_VS30_MAP_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_vs30_map():
-    return utils.proxy_to_api(
-        request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN
-    )
+@decorators.get_authentication
+def get_vs30_map(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard"):
+        return utils.proxy_to_api(
+            request, const.SITE_VS30_MAP_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_VS30_SOIL_CLASS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_soil_class_from_vs30():
-    return utils.proxy_to_api(
-        request,
-        const.SITE_VS30_SOIL_CLASS_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-    )
+@decorators.get_authentication
+def get_soil_class_from_vs30(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard"):
+        return utils.proxy_to_api(
+            request,
+            const.SITE_VS30_SOIL_CLASS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_STATION_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_station():
-    return utils.proxy_to_api(
-        request,
-        const.SITE_LOCATION_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Set Station",
-    )
+@decorators.get_authentication
+def get_station(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard"):
+        return utils.proxy_to_api(
+            request,
+            const.SITE_LOCATION_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Set Station",
+        )
+    else:
+        raise auth0.AuthError()
 
 
 # Seismic Hazard
 @app.route(const.CORE_API_HAZARD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_hazard():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_hazard(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.ENSEMBLE_HAZARD_ENDPOINT,
@@ -94,19 +116,14 @@ def get_hazard():
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Hazard Curve Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_hazard_nzs1170p5():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_hazard_nzs1170p5(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZS1170p5_HAZARD_ENDPOINT,
@@ -116,39 +133,25 @@ def get_hazard_nzs1170p5():
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Hazard NZS1170p5 Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_SOIL_CLASS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_nzs1170p5_soil_class():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_nzs1170p5_soil_class(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
-            request,
-            const.NZS1170p5_SOIL_CLASS,
-            "GET",
-            CORE_API_BASE,
-            CORE_API_TOKEN,
+            request, const.NZS1170p5_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZS1170P5_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_nzs1170p5_default_params():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_nzs1170p5_default_params(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZS1170p5_DEFAULT_PARAMS_ENDPOINT,
@@ -156,19 +159,14 @@ def get_nzs1170p5_default_params():
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_hazard_nzta():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_hazard_nzta(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZTA_HAZARD_ENDPOINT,
@@ -178,39 +176,25 @@ def get_hazard_nzta():
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Hazard NZTA Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_SOIL_CLASS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_nzta_soil_class():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_nzta_soil_class(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
-            request,
-            const.NZTA_SOIL_CLASS,
-            "GET",
-            CORE_API_BASE,
-            CORE_API_TOKEN,
+            request, const.NZTA_SOIL_CLASS, "GET", CORE_API_BASE, CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_NZTA_DEFAULT_PARAMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_nzta_default_params():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_nzta_default_params(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:hazard"):
         return utils.proxy_to_api(
             request,
             const.NZTA_DEFAULT_PARAMS_ENDPOINT,
@@ -218,19 +202,14 @@ def get_nzta_default_params():
             CORE_API_BASE,
             CORE_API_TOKEN,
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_disagg():
-    if auth0.requires_permission("hazard:disagg"):
+@decorators.get_authentication
+def get_disagg(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:disagg"):
         return utils.proxy_to_api(
             request,
             const.ENSEMBLE_DISAGG_ENDPOINT,
@@ -240,19 +219,14 @@ def get_disagg():
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - Disaggregation Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_UHS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_uhs():
-    if auth0.requires_permission("hazard:uhs"):
+@decorators.get_authentication
+def get_uhs(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:uhs"):
         return utils.proxy_to_api(
             request,
             const.ENSEMBLE_UHS_ENDPOINT,
@@ -262,19 +236,14 @@ def get_uhs():
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - UHS Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_UHS_NZS1170P5_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_uhs_nzs1170p5():
-    if auth0.requires_permission("hazard:hazard"):
+@decorators.get_authentication
+def get_uhs_nzs1170p5(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:uhs"):
         return utils.proxy_to_api(
             request,
             const.NZS1170p5_UHS_ENDPOINT,
@@ -284,166 +253,190 @@ def get_uhs_nzs1170p5():
             user_id=auth0.get_user_id(),
             action="Hazard Analysis - UHS NZS1170p5 Compute",
         )
-    raise auth0.AuthError(
-        {
-            "code": "Unauthorized",
-            "description": "You don't have access to this resource",
-        },
-        const.NO_ACCESS_RIGHT_CODE,
-    )
+    else:
+        raise auth0.AuthError()
 
 
 # GMS
 @app.route(const.CORE_API_GMS_ENDPOINT, methods=["POST"])
-@decorators.requires_auth
-def compute_ensemble_gms():
-    return utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_GMS_COMPUTE_ENDPOINT,
-        "POST",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        data=request.data.decode(),
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - GMS Compute",
-    )
+@decorators.get_authentication
+def compute_ensemble_gms(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_GMS_COMPUTE_ENDPOINT,
+            "POST",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            data=request.data.decode(),
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - GMS Compute",
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_IM_WEIGHTS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_default_im_weights():
-    return utils.proxy_to_api(
-        request,
-        const.GMS_DEFAULT_IM_WEIGHTS_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-    )
+@decorators.get_authentication
+def get_default_im_weights(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.GMS_DEFAULT_IM_WEIGHTS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def get_default_causal_params():
-    return utils.proxy_to_api(
-        request,
-        const.GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-    )
+@decorators.get_authentication
+def get_default_causal_params(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.GMS_DEFAULT_CAUSAL_PARAMS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
-# GMS
 @app.route(const.CORE_API_GMS_DATASETS_ENDPOINT, methods=["GET"])
-def get_gm_datasets():
-    return utils.proxy_to_api(
-        request, const.GMS_GM_DATASETS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN
-    )
+@decorators.get_authentication
+def get_gm_datasets(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request,
+            const.GMS_GM_DATASETS_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_GMS_IMS_ENDPOINT_ENDPOINT, methods=["GET"])
-def get_gms_available_ims():
-    return utils.proxy_to_api(
-        request, const.GMS_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN
-    )
+@decorators.get_authentication
+def get_gms_available_ims(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:gms"):
+        return utils.proxy_to_api(
+            request, const.GMS_IMS_ENDPOINT, "GET", CORE_API_BASE, CORE_API_TOKEN,
+        )
+    else:
+        raise auth0.AuthError()
 
 
 # Scenarios
 @app.route(const.CORE_API_SCENARIOS_ENDPOINT, methods=["GET"])
-def get_scenario():
-    return utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_SCENARIO_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Scenarios Get",
-    )
+@decorators.get_authentication
+def get_scenario(is_authenticated):
+    if is_authenticated and auth0.requires_permission("hazard:scenarios"):
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_SCENARIO_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Scenarios Get",
+        )
+    else:
+        raise auth0.AuthError()
 
 
 # Download
 # CORE API
 @app.route(const.CORE_API_HAZARD_CURVE_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def core_api_download_hazard():
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_HAZARD_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Hazard Download",
-        content_type="application/zip",
-    )
-
-    return core_response
+@decorators.get_authentication
+def core_api_download_hazard(is_authenticated):
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_HAZARD_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Hazard Download",
+            content_type="application/zip",
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_DISAGG_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def core_api_download_disagg():
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_DISAGG_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Disaggregation Download",
-        content_type="application/zip",
-    )
-
-    return core_response
+@decorators.get_authentication
+def core_api_download_disagg(is_authenticated):
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_DISAGG_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Disaggregation Download",
+            content_type="application/zip",
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(const.CORE_API_HAZARD_UHS_DOWNLOAD_ENDPOINT, methods=["GET"])
-@decorators.requires_auth
-def core_api_download_uhs():
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_UHS_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - UHS Download",
-        content_type="application/zip",
-    )
-
-    return core_response
+@decorators.get_authentication
+def core_api_download_uhs(is_authenticated):
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_UHS_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - UHS Download",
+            content_type="application/zip",
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(f"{const.CORE_API_GMS_DOWNLOAD_ENDPOINT}/<token>", methods=["GET"])
-@decorators.requires_auth
-def core_api_download_gms(token):
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_GMS_DOWNLOAD_ENDPOINT + "/" + token,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - GMS Download",
-        content_type="application/zip",
-    )
-
-    return core_response
+@decorators.get_authentication
+def core_api_download_gms(is_authenticated, token):
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_GMS_DOWNLOAD_ENDPOINT + "/" + token,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - GMS Download",
+            content_type="application/zip",
+        )
+    else:
+        raise auth0.AuthError()
 
 
 @app.route(f"{const.CORE_API_SCENARIOS_DOWNLOAD_ENDPOINT}", methods=["GET"])
-@decorators.requires_auth
-def core_api_download_scenario():
-    core_response = utils.proxy_to_api(
-        request,
-        const.ENSEMBLE_SCENARIO_DOWNLOAD_ENDPOINT,
-        "GET",
-        CORE_API_BASE,
-        CORE_API_TOKEN,
-        user_id=auth0.get_user_id(),
-        action="Hazard Analysis - Scenarios Download",
-        content_type="application/zip",
-    )
-
-    return core_response
+@decorators.get_authentication
+def core_api_download_scenario(is_authenticated):
+    if is_authenticated:
+        return utils.proxy_to_api(
+            request,
+            const.ENSEMBLE_SCENARIO_DOWNLOAD_ENDPOINT,
+            "GET",
+            CORE_API_BASE,
+            CORE_API_TOKEN,
+            user_id=auth0.get_user_id(),
+            action="Hazard Analysis - Scenarios Download",
+            content_type="application/zip",
+        )
+    else:
+        raise auth0.AuthError()

--- a/apis/intermediate_api/intermediate_api/auth0.py
+++ b/apis/intermediate_api/intermediate_api/auth0.py
@@ -119,6 +119,7 @@ def _get_management_api_token():
 
 def get_users():
     """Get all users
+
     Returns
     -------
     dictionary:
@@ -157,6 +158,7 @@ def get_users():
 
 def requires_permission(required_permission):
     """Determines if the required scope is present in the Access Token
+
     Parameters
     ----------
     required_permission: string

--- a/apis/intermediate_api/intermediate_api/auth0.py
+++ b/apis/intermediate_api/intermediate_api/auth0.py
@@ -20,9 +20,18 @@ AUTH0_DOMAIN = os.environ["AUTH0_DOMAIN"]
 
 
 class AuthError(Exception):
-    def __init__(self, error, status_code):
-        self.error = error
-        self.status_code = status_code
+    def __init__(self, error=None, status_code=None):
+        self.error = (
+            error
+            if error is not None
+            else {
+                "code": "Unauthorized",
+                "description": "You don't have access to this resource",
+            }
+        )
+        self.status_code = (
+            status_code if status_code is not None else const.NO_ACCESS_RIGHT_CODE
+        )
 
 
 @app.errorhandler(AuthError)
@@ -110,7 +119,6 @@ def _get_management_api_token():
 
 def get_users():
     """Get all users
-
     Returns
     -------
     dictionary:
@@ -149,7 +157,6 @@ def get_users():
 
 def requires_permission(required_permission):
     """Determines if the required scope is present in the Access Token
-
     Parameters
     ----------
     required_permission: string
@@ -163,3 +170,7 @@ def requires_permission(required_permission):
         return required_permission in token_permissions
 
     return False
+
+
+def is_admin():
+    return requires_permission("admin")

--- a/apis/intermediate_api/intermediate_api/create_db.py
+++ b/apis/intermediate_api/intermediate_api/create_db.py
@@ -21,7 +21,7 @@ PERMISSION_LIST = [
     "hazard:uhs",
     "hazard:gms",
     "project",
-    "psha-admin",
+    "admin",
 ]
 
 # Adding all users from Auth0 to the User table

--- a/apis/intermediate_api/intermediate_api/decorators.py
+++ b/apis/intermediate_api/intermediate_api/decorators.py
@@ -19,7 +19,7 @@ ALGORITHMS = os.environ["ALGORITHMS"]
 API_AUDIENCE = os.environ["API_AUDIENCE"]
 
 
-def requires_auth(f):
+def get_authentication(f):
     """Determines if the Access Token is valid"""
 
     @wraps(f)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,7 +57,7 @@ const App = () => {
 
                 <PrivateRoute
                   path="/permission-config"
-                  permission="psha-admin"
+                  permission="admin"
                   exact
                   component={PermissionConfig}
                 />

--- a/frontend/src/components/NavBar/LogoutButton.js
+++ b/frontend/src/components/NavBar/LogoutButton.js
@@ -52,7 +52,7 @@ const LogoutButton = () => {
           </DropdownItem>
         ) : null}
 
-        {hasPermission("psha-admin") ? (
+        {hasPermission("admin") ? (
           <DropdownItem
             tag={RouterNavLink}
             to="/permission-config"


### PR DESCRIPTION
# Update Core API's Authentication structure

Basically a split version of #30.  There will be two more, one for Intermediate API and another one for Project API.
Once three different PRs go through, the `remove_a_few_items` branch should be identical to `update_auth_structure`.

## Core API
- Must be authenticated via Auth0
- Must have certain permission with Auth0 to use, such as
    - hazard - To be able to access to non-projects tab and Site Selection
    - hazard:hazard - To use Hazard Curve
    - hazard:disagg - To use Disaggregation

![GMHazard_Updated_Authentication_structure drawio (1)](https://user-images.githubusercontent.com/7849113/141877540-0229d73b-50c6-4397-b4e5-2d64f4b83f27.png)