### PR TITLE
Fix the Core API test

### DIFF
--- a/apis/core_api/core_api/test/test_core_gm_data.py
+++ b/apis/core_api/core_api/test/test_core_gm_data.py
@@ -22,7 +22,7 @@ def test_get_ensemble_ims(config):
     )
 
 
-def test_get_ensemble_ims_missingparam(config):
+def test_get_ensemble_ims_missing_param(config):
     """ Tests the failed get request of a Ensemble's IM's without parameters"""
     response = tu.send_test_request(constants.ENSEMBLE_IMS_ENDPOINT)
     tu.response_checks(

--- a/apis/core_api/core_api/test/test_core_gms.py
+++ b/apis/core_api/core_api/test/test_core_gms.py
@@ -61,7 +61,10 @@ def test_post_gms_compute_missing_json(config):
         ),
     )
     tu.response_checks(
-        response, [("error", str)], [("error", tu.MISSING_PARAM_MSG.format("station"))], 400
+        response,
+        [("error", str)],
+        [("error", tu.MISSING_PARAM_MSG.format("station"))],
+        400,
     )
 
 
@@ -82,7 +85,7 @@ def test_get_gms_compute_download(config):
     )
     response = tu.send_test_request(
         constants.ENSEMBLE_GMS_DOWNLOAD_ENDPOINT,
-        url_extension="/" + response_compute.json()["download_token"],
+        {"gms_token": response_compute.json()["download_token"],},
     )
     tu.response_checks(response, [], [], 200, "application/zip")
 
@@ -90,7 +93,7 @@ def test_get_gms_compute_download(config):
 def test_get_gms_compute_download_missing_token(config):
     """ Tests the failed get request of a GMS compute download with missing token"""
     response = tu.send_test_request(constants.ENSEMBLE_GMS_DOWNLOAD_ENDPOINT)
-    tu.response_checks(response, [], [], 404, "text/html; charset=utf-8")
+    tu.response_checks(response, [], [], 400)
 
 
 def test_get_gms_default_im_weights(config):
@@ -100,19 +103,14 @@ def test_get_gms_default_im_weights(config):
         {"IM_j": config["gms"]["IM_j"], "IMs": config["gms"]["IMs"]},
     )
     tu.response_checks(
-        response,
-        [
-            (config["gms"]["IMs"], float),
-        ],
-        [],
+        response, [(config["gms"]["IMs"], float),], [],
     )
 
 
 def test_get_gms_default_im_weights_missing_parameter(config):
     """ Tests the failed get request of a GMS default IM weights with missing parameter"""
     response = tu.send_test_request(
-        constants.GMS_DEFAULT_IM_WEIGHTS_ENDPOINT,
-        {"IM_j": config["gms"]["IM_j"]},
+        constants.GMS_DEFAULT_IM_WEIGHTS_ENDPOINT, {"IM_j": config["gms"]["IM_j"]},
     )
     tu.response_checks(
         response, [("error", str)], [("error", tu.MISSING_PARAM_MSG.format("IMs"))], 400
@@ -129,19 +127,14 @@ def test_get_gms_ims(config):
         },
     )
     tu.response_checks(
-        response,
-        [
-            ("ims", list),
-        ],
-        [],
+        response, [("ims", list),], [],
     )
 
 
 def test_get_gms_ims_missing_parameter(config):
     """ Tests the failed get request of a GMS IMs with missing parameter"""
     response = tu.send_test_request(
-        constants.GMS_IMS_ENDPOINT,
-        {"ensemble_id": config["general"]["ensemble_id"]},
+        constants.GMS_IMS_ENDPOINT, {"ensemble_id": config["general"]["ensemble_id"]},
     )
     tu.response_checks(
         response,
@@ -204,16 +197,12 @@ def test_get_gms_default_casual_parameters_missing_parameter(config):
 
 def test_get_gms_datasets(config):
     """ Tests the sucessful get request of a GMS datasets"""
-    response = tu.send_test_request(
-        constants.GMS_GM_DATASETS_ENDPOINT,
-    )
+    response = tu.send_test_request(constants.GMS_GM_DATASETS_ENDPOINT,)
     check_list = []
     for dataset in config["gms_datasets"]:
         check_list.append((dataset, object))
         check_list.append(([dataset, "name"], str))
         check_list.append(([dataset, "type"], str))
     tu.response_checks(
-        response,
-        check_list,
-        [],
+        response, check_list, [],
     )

--- a/apis/core_api/core_api/test/test_core_hazard.py
+++ b/apis/core_api/core_api/test/test_core_hazard.py
@@ -6,8 +6,7 @@ from core_api import constants
 def test_get_ensemble_hazard(config):
     """ Tests the successful get request of a ensemble hazard"""
     response = tu.send_test_request(
-        constants.ENSEMBLE_HAZARD_ENDPOINT,
-        {**config["general"], **config["hazard"]},
+        constants.ENSEMBLE_HAZARD_ENDPOINT, {**config["general"], **config["hazard"]},
     )
     check_list = [
         ("ensemble_id", str),
@@ -40,7 +39,7 @@ def test_get_ensemble_hazard(config):
     )
 
 
-def test_get_ensemble_hazard_missingparam(config):
+def test_get_ensemble_hazard_missing_param(config):
     """ Tests the failed get request of a Ensemble's hazard without parameters"""
     response = tu.send_test_request(
         constants.ENSEMBLE_HAZARD_ENDPOINT,
@@ -57,12 +56,10 @@ def test_get_ensemble_hazard_missingparam(config):
 def test_get_ensemble_hazard_download(config):
     """ Tests the successful get request of a ensemble hazard download"""
     response_hazard = tu.send_test_request(
-        constants.ENSEMBLE_HAZARD_ENDPOINT,
-        {**config["general"], **config["hazard"]},
+        constants.ENSEMBLE_HAZARD_ENDPOINT, {**config["general"], **config["hazard"]},
     )
     response_nzs1170p5 = tu.send_test_request(
-        constants.NZS1170p5_HAZARD_ENDPOINT,
-        config["general"],
+        constants.NZS1170p5_HAZARD_ENDPOINT, config["general"],
     )
     response = tu.send_test_request(
         constants.ENSEMBLE_HAZARD_DOWNLOAD_ENDPOINT,
@@ -74,7 +71,7 @@ def test_get_ensemble_hazard_download(config):
     tu.response_checks(response, [], [], 200, "application/zip")
 
 
-def test_get_ensemble_hazard_download_missingparam():
+def test_get_ensemble_hazard_download_missing_param():
     """ Tests the failed get request of a Ensemble's hazard download without parameters"""
     response = tu.send_test_request(constants.ENSEMBLE_HAZARD_DOWNLOAD_ENDPOINT)
     tu.response_checks(
@@ -89,8 +86,7 @@ def test_get_ensemble_hazard_user_vs30(config):
     """Tests the successful get request of a ensemble hazard with a
     different set of vs30 and ensure the result is different to the db vs30 calculations"""
     response_db = tu.send_test_request(
-        constants.ENSEMBLE_HAZARD_ENDPOINT,
-        {**config["general"], **config["hazard"]},
+        constants.ENSEMBLE_HAZARD_ENDPOINT, {**config["general"], **config["hazard"]},
     )
     response_user = tu.send_test_request(
         constants.ENSEMBLE_HAZARD_ENDPOINT,

--- a/apis/core_api/core_api/test/test_core_nzs1170p5.py
+++ b/apis/core_api/core_api/test/test_core_nzs1170p5.py
@@ -33,7 +33,7 @@ def test_get_nzs1170p5_ensemble_hazard(config):
     )
 
 
-def test_get_nzs1170p5_ensemble_hazard_missingparam(config):
+def test_get_nzs1170p5_ensemble_hazard_missing_param(config):
     """ Tests the failed get request of a NZS1170p5 ensemble hazard"""
     response = tu.send_test_request(
         constants.NZS1170p5_HAZARD_ENDPOINT,
@@ -73,7 +73,7 @@ def test_get_nzs1170p5_uhs(config):
     )
 
 
-def test_get_nzs1170p5_uhs_missingparam(config):
+def test_get_nzs1170p5_uhs_missing_param(config):
     """ Tests the failed get request of a NZS1170p5 UHS"""
     response = tu.send_test_request(
         constants.NZS1170p5_UHS_ENDPOINT,
@@ -106,7 +106,7 @@ def test_get_nzs1170p5_default(config):
     )
 
 
-def test_get_nzs1170p5_default_missingparam(config):
+def test_get_nzs1170p5_default_missing_param(config):
     """ Tests the failed get request of a NZS1170p5 default parameters"""
     response = tu.send_test_request(
         constants.NZS1170p5_DEFAULT_PARAMS_ENDPOINT,

--- a/apis/core_api/core_api/test/test_core_scenarios.py
+++ b/apis/core_api/core_api/test/test_core_scenarios.py
@@ -34,7 +34,7 @@ def test_get_ensemble_scenario(config):
     )
 
 
-def test_get_ensemble_scenario_missingparam(config):
+def test_get_ensemble_scenario_missing_param(config):
     """ Tests the failed get request of an ensemble scenario without parameters"""
     response = tu.send_test_request(
         constants.ENSEMBLE_SCENARIO_ENDPOINT,
@@ -66,7 +66,7 @@ def test_get_ensemble_scenario_download(config):
     tu.response_checks(response, [], [], 200, "application/zip")
 
 
-def test_get_ensemble_scenario_download_missingparam():
+def test_get_ensemble_scenario_download_missing_param():
     """ Tests the failed get request of an ensemble scenario download without parameters"""
     response = tu.send_test_request(
         constants.ENSEMBLE_SCENARIO_DOWNLOAD_ENDPOINT,

--- a/apis/project_api/project_api/test/test_hazard.py
+++ b/apis/project_api/project_api/test/test_hazard.py
@@ -43,7 +43,7 @@ def test_get_hazard(config):
     )
 
 
-def test_get_hazard_missingparam(config):
+def test_get_hazard_missing_param(config):
     """ Tests the failed get request of a hazard without parameters"""
     response = tu.send_test_request(
         constants.PROJECT_HAZARD_ENDPOINT,
@@ -72,7 +72,7 @@ def test_get_hazard_download(config):
     tu.response_checks(response, [], [], 200, "application/zip")
 
 
-def test_get_hazard_download_missingparam():
+def test_get_hazard_download_missing_param():
     """ Tests the failed get request of a hazard download without parameters"""
     response = tu.send_test_request(
         constants.PROJECT_HAZARD_DOWNLOAD_ENDPOINT,

--- a/apis/project_api/project_api/test/test_scenarios.py
+++ b/apis/project_api/project_api/test/test_scenarios.py
@@ -32,7 +32,7 @@ def test_get_scenario(config):
     )
 
 
-def test_get_scenario_missingparam(config):
+def test_get_scenario_missing_param(config):
     """ Tests the failed get request of a scenario without parameters"""
     response = tu.send_test_request(
         constants.PROJECT_SCENARIO_ENDPOINT,
@@ -64,7 +64,7 @@ def test_get_scenario_download(config):
     tu.response_checks(response, [], [], 200, "application/zip")
 
 
-def test_get_scenario_download_missingparam():
+def test_get_scenario_download_missing_param():
     """ Tests the failed get request of a scenario download without parameters"""
     response = tu.send_test_request(
         constants.PROJECT_SCENARIO_DOWNLOAD_ENDPOINT,


### PR DESCRIPTION
# Fix the Core API test

- Rename `missingparam` to `missing_param`
- Missing download token
    - Update on status code from 404 to 400
    - Update on content-type from html/text to application/json 
![image](https://user-images.githubusercontent.com/7849113/143789414-66ad1f86-2087-4334-956c-c1bbe90a27ef.png)
- Remove url_extension for Core GMS download
    - TODO: Update the Projects download all then we can eliminate `url_extension` parameter to simplify. 


![image](https://user-images.githubusercontent.com/7849113/143789244-01e149b5-c328-4157-87d4-544e3d730beb.png)
