### PR TITLE
Error prevention - Missing NZ code for Hazard Curve download

### DIFF
--- a/apis/project_api/CHANGELOG.md
+++ b/apis/project_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [21.8.3] - 2021-12-06 -- Projects - Download Hazard Curve
+### Changed
+    - Projects API - NZS1170p5 is now an optional parameter for downloading Hazard Curve data
+        - By supporting more IM(Not just pSA and PGA) they may not have any NZ Code data(NZS1170p5 or NZTA)
 ## [21.8.2] - 2021-11-26 -- Download GMS no longer needs a token as a parameter
 ### Changed
     - Non-projects GMS download endpoint no longer needs a token as a parameter

--- a/apis/project_api/project_api/api/hazard.py
+++ b/apis/project_api/project_api/api/hazard.py
@@ -114,7 +114,10 @@ def download_ens_hazard():
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         zip_ffp = su.api.create_hazard_download_zip(
-            ensemble_hazard, nzs1170p5_hazard, tmp_dir, nzta_hazard=nzta_hazard,
+            ensemble_hazard,
+            tmp_dir,
+            nzs1170p5_hazard=nzs1170p5_hazard,
+            nzta_hazard=nzta_hazard,
         )
 
         return flask.send_file(

--- a/apis/project_api/project_api/utils.py
+++ b/apis/project_api/project_api/utils.py
@@ -139,11 +139,7 @@ def load_hazard_data(results_dir: Path, im: sc.im.IM):
     )
 
     nzta_hazard = (
-        (
-            sc.nz_code.nzta_2018.NZTAResult.load(results_dir / "hazard_nzta")
-            if im.im_type == sc.im.IMType.PGA
-            else None
-        )
+        sc.nz_code.nzta_2018.NZTAResult.load(results_dir / "hazard_nzta")
         if im.im_type == sc.im.IMType.pSA or im.im_type == sc.im.IMType.PGA
         else None
     )

--- a/apis/project_api/setup.py
+++ b/apis/project_api/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="project_api",
-    version="21.8.2",
+    version="21.8.3",
     packages=find_packages(),
     url="https://github.com/ucgmsim/gmhazard",
     description="GMHazard Project API",


### PR DESCRIPTION
# Error prevention - Missing NZ code for Hazard Curve download

As we now support more IMs(Not just pSA or PGA), NZS1170.5 code is now an optional parameter.

## Before an update - When trying to download Hazard Curve data with IM, PGV
![image](https://user-images.githubusercontent.com/7849113/144770290-4e62beef-537d-44e3-acca-efb092e686a1.png)

## After an update - Managed to download with PGV
![image](https://user-images.githubusercontent.com/7849113/144770358-afe497ed-2404-448e-8fd3-d98f921bf641.png)
Of course with PGV, neither NZS1170.5 nor NZTA available, metadata will look slightly different to another
![image](https://user-images.githubusercontent.com/7849113/144770379-a9fe291a-181a-496e-bc0e-48b179ddf74b.png)
Example Metadata.yaml with PGA
![image](https://user-images.githubusercontent.com/7849113/144770420-503842d6-523b-4b62-8134-b3e4ca7a03c9.png)


