### PR TITLE
Hotfix api test

### DIFF
--- a/apis/core_api/core_api/api/hazard.py
+++ b/apis/core_api/core_api/api/hazard.py
@@ -189,8 +189,8 @@ def download_ens_hazard():
     with tempfile.TemporaryDirectory() as tmp_dir:
         zip_ffp = su.api.create_hazard_download_zip(
             ensemble_hazard,
-            nzs1170p5_hazard,
             tmp_dir,
+            nzs1170p5_hazard=nzs1170p5_hazard,
             nzta_hazard=nzta_hazard,
             prefix=f"{ensemble.name}",
         )


### PR DESCRIPTION
# HOTFIX - Core API test

- Fixed the Core API test by changing the order of args order for Core API's Hazard Curve download function.
- While fixing the Core API test, might as well update the Core API's download to make the `nzs1170p5` token an optional argument.

## All Core API tests are passed
![image](https://user-images.githubusercontent.com/7849113/145132438-c21b4199-6ad0-4019-ba4e-62c6dbe4d14d.png)

## Downloaded data without any NZ Code (Neither NZS1170.5 nor NZTA)
![image](https://user-images.githubusercontent.com/7849113/145128616-f48d3c36-f917-4b07-b4dc-8d55ed9aaf50.png)
