### PR TITLE
Fix reset states

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,3 +1,14 @@
+## December 9, 2021
+
+### Reset useState hooks at the right timing - ([PR #4](https://github.com/ucgmsim/gmhazard/pull/44))
+
+- Main changes
+  - Reset the `useState` hook at the right timing
+  - Reset any useStates when the user clicks a get button from the Site Selection tab
+- Minor changes
+  - Change the order of useEffect, any useEffect to reset variables will now be at the top of the component. (Still below any `useState`)
+  - Changed the way of checking the size of the array from a !== [] to a.length !== 0 as with JS, [] !== [] will always be true.
+
 ## December 1, 2021
 
 ### Deploying GMHazard web app to subdirectory - ([PR #39](https://github.com/ucgmsim/gmhazard/pull/39))

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -2,12 +2,8 @@
 
 ### Reset useState hooks at the right timing - ([PR #4](https://github.com/ucgmsim/gmhazard/pull/44))
 
-- Main changes
-  - Reset the `useState` hook at the right timing
-  - Reset any useStates when the user clicks a get button from the Site Selection tab
-- Minor changes
-  - Change the order of useEffect, any useEffect to reset variables will now be at the top of the component. (Still below any `useState`)
-  - Changed the way of checking the size of the array from a !== [] to a.length !== 0 as with JS, [] !== [] will always be true.
+- Reset the states when the Projects view component gets unmounted to prevent sending a request.
+  - This fixes the issue that the app may get crashed when they access to Projects page after visiting Home or Framework Documents.
 
 ## December 1, 2021
 

--- a/frontend/src/components/Project/GMS/GMSForm.js
+++ b/frontend/src/components/Project/GMS/GMSForm.js
@@ -36,6 +36,14 @@ const GMSForm = () => {
     );
   };
 
+  const setGlobalVariables = () => {
+    setProjectGMSConditionIM(localGMSConditionIM["value"]);
+    setProjectGMSSelectedIMPeriod(localGMSIMPeriod["value"]);
+    setProjectGMSExceedance(localGMSExceedance["value"]);
+    setProjectGMSIMVector(localGMSIMVector["value"]);
+    setProjectGMSGetClick(uuidv4());
+  };
+
   return (
     <Fragment>
       <div className="form-group form-section-title">
@@ -98,13 +106,7 @@ const GMSForm = () => {
           type="button"
           className="btn btn-primary"
           disabled={invalidInputs()}
-          onClick={() => {
-            setProjectGMSConditionIM(localGMSConditionIM["value"]);
-            setProjectGMSSelectedIMPeriod(localGMSIMPeriod["value"]);
-            setProjectGMSExceedance(localGMSExceedance["value"]);
-            setProjectGMSIMVector(localGMSIMVector["value"]);
-            setProjectGMSGetClick(uuidv4());
-          }}
+          onClick={() => setGlobalVariables()}
         >
           Get
         </button>

--- a/frontend/src/components/Project/GMS/GMSViewer.js
+++ b/frontend/src/components/Project/GMS/GMSViewer.js
@@ -77,12 +77,6 @@ const GmsViewer = () => {
   // For Download data button
   const [downloadToken, setDownloadToken] = useState("");
 
-  // Reset the state to prevent auto-trigger
-  // E.g. change tab between Projects and Hazard Analyis
-  useEffect(() => {
-    setProjectGMSGetClick(null);
-  }, []);
-
   // Reset tabs if users change project id, project location or project vs30
   useEffect(() => {
     setIsLoading(false);
@@ -92,7 +86,7 @@ const GmsViewer = () => {
     });
     setComputedGMS(null);
     setProjectGMSGetClick(null);
-  }, [projectId, projectLocation, projectVS30]);
+  }, [projectId, projectLocation, projectVS30, projectZ1p0, projectZ2p5]);
 
   // Create IM array of objects for IM Distributions plot (react-select dropdown)
   useEffect(() => {

--- a/frontend/src/components/Project/GMS/GMSViewer.js
+++ b/frontend/src/components/Project/GMS/GMSViewer.js
@@ -50,6 +50,7 @@ const GmsViewer = () => {
     projectGMSExceedance,
     projectGMSIMVector,
     projectGMSNumGMs,
+    projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   // For fetching GMS data
@@ -77,16 +78,18 @@ const GmsViewer = () => {
   // For Download data button
   const [downloadToken, setDownloadToken] = useState("");
 
-  // Reset tabs if users change project id, project location or project vs30
+  // Reset tabs if users click Get button from Site Selection
   useEffect(() => {
-    setIsLoading(false);
-    setShowErrorMessage({
-      isError: false,
-      errorCode: null,
-    });
-    setComputedGMS(null);
-    setProjectGMSGetClick(null);
-  }, [projectId, projectLocation, projectVS30, projectZ1p0, projectZ2p5]);
+    if (projectSiteSelectionGetClick !== null) {
+      setIsLoading(false);
+      setShowErrorMessage({
+        isError: false,
+        errorCode: null,
+      });
+      setComputedGMS(null);
+      setProjectGMSGetClick(null);
+    }
+  }, [projectSiteSelectionGetClick]);
 
   // Create IM array of objects for IM Distributions plot (react-select dropdown)
   useEffect(() => {

--- a/frontend/src/components/Project/Scenarios/ScenarioForm.js
+++ b/frontend/src/components/Project/Scenarios/ScenarioForm.js
@@ -20,11 +20,7 @@ const ScenarioForm = () => {
     projectScenarioData,
     setProjectScenarioData,
     setProjectScenarioSelectedRuptures,
-    projectId,
-    projectVS30,
-    projectLocation,
-    projectZ1p0,
-    projectZ2p5,
+    projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   const [localSelectedIMComponent, setLocalSelectedIMComponent] =
@@ -32,12 +28,14 @@ const ScenarioForm = () => {
   const [localRuptureOptions, setLocalRuptureOptions] = useState([]);
   const [localRuptures, setLocalRuptures] = useState([]);
 
-  // Reset tabs if users change Project ID, Vs30, Z values or Location
+  // Reset tabs if users click Get button from Site Selection
   useEffect(() => {
-    setLocalRuptures([]);
-    setLocalSelectedIMComponent(null);
-    setProjectScenarioData(null);
-  }, [projectId, projectVS30, projectLocation, projectZ1p0, projectZ2p5]);
+    if (projectSiteSelectionGetClick !== null) {
+      setLocalRuptures([]);
+      setLocalSelectedIMComponent(null);
+      setProjectScenarioData(null);
+    }
+  }, [projectSiteSelectionGetClick]);
 
   useEffect(() => {
     if (localSelectedIMComponent !== null) {
@@ -60,14 +58,18 @@ const ScenarioForm = () => {
   }, [projectScenarioData]);
 
   useEffect(() => {
-    if (localRuptures !== []) {
-      const rupture_values = [];
-      for (const key in localRuptures) {
-        rupture_values.push(localRuptures[key]["value"]);
-      }
-      setProjectScenarioSelectedRuptures(rupture_values);
+    if (localRuptures.length !== 0) {
+      setProjectScenarioSelectedRuptures(
+        localRuptures.map((rupture) => rupture["value"])
+      );
     }
   }, [localRuptures]);
+
+  const setGlobalVariables = () => {
+    setLocalRuptures([]);
+    setProjectScenarioSelectedRuptures([]);
+    setProjectScenarioGetClick(uuidv4());
+  };
 
   return (
     <Fragment>
@@ -93,7 +95,7 @@ const ScenarioForm = () => {
           type="button"
           className="btn btn-primary"
           disabled={localSelectedIMComponent === null}
-          onClick={() => setProjectScenarioGetClick(uuidv4())}
+          onClick={() => setGlobalVariables()}
         >
           Compute
         </button>

--- a/frontend/src/components/Project/Scenarios/ScenarioForm.js
+++ b/frontend/src/components/Project/Scenarios/ScenarioForm.js
@@ -32,6 +32,13 @@ const ScenarioForm = () => {
   const [localRuptureOptions, setLocalRuptureOptions] = useState([]);
   const [localRuptures, setLocalRuptures] = useState([]);
 
+  // Reset tabs if users change Project ID, Vs30, Z values or Location
+  useEffect(() => {
+    setLocalRuptures([]);
+    setLocalSelectedIMComponent(null);
+    setProjectScenarioData(null);
+  }, [projectId, projectVS30, projectLocation, projectZ1p0, projectZ2p5]);
+
   useEffect(() => {
     if (localSelectedIMComponent !== null) {
       setProjectSelectedScenarioIMComponent(localSelectedIMComponent["value"]);
@@ -61,13 +68,6 @@ const ScenarioForm = () => {
       setProjectScenarioSelectedRuptures(rupture_values);
     }
   }, [localRuptures]);
-
-  // Reset tabs if users change Project ID, Vs30, Z values or Location
-  useEffect(() => {
-    setLocalRuptures([]);
-    setLocalSelectedIMComponent(null);
-    setProjectScenarioData(null);
-  }, [projectId, projectVS30, projectLocation, projectZ1p0, projectZ2p5]);
 
   return (
     <Fragment>

--- a/frontend/src/components/Project/Scenarios/ScenarioForm.js
+++ b/frontend/src/components/Project/Scenarios/ScenarioForm.js
@@ -97,7 +97,7 @@ const ScenarioForm = () => {
           disabled={localSelectedIMComponent === null}
           onClick={() => setGlobalVariables()}
         >
-          Compute
+          Get
         </button>
       </div>
 

--- a/frontend/src/components/Project/Scenarios/ScenarioViewer.js
+++ b/frontend/src/components/Project/Scenarios/ScenarioViewer.js
@@ -32,6 +32,7 @@ const ScenarioViewer = () => {
     setProjectScenarioData,
     projectScenarioSelectedRuptures,
     projectSelectedScenarioIMComponent,
+    projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   // For fetching Scenario data
@@ -47,11 +48,13 @@ const ScenarioViewer = () => {
   // For Download data button
   const [downloadToken, setDownloadToken] = useState("");
 
-  // Reset tabs if users change Project ID, Vs30, Z values or Location
+  // Reset tabs if users click Get button from Site Selection
   useEffect(() => {
-    setProjectScenarioGetClick(null);
-    setShowErrorMessage({ isError: false, errorCode: null });
-  }, [projectId, projectVS30, projectLocation, projectZ1p0, projectZ2p5]);
+    if (projectSiteSelectionGetClick !== null) {
+      setProjectScenarioGetClick(null);
+      setShowErrorMessage({ isError: false, errorCode: null });
+    }
+  }, [projectSiteSelectionGetClick]);
 
   // Get Scenario data
   useEffect(() => {

--- a/frontend/src/components/Project/Scenarios/ScenarioViewer.js
+++ b/frontend/src/components/Project/Scenarios/ScenarioViewer.js
@@ -47,6 +47,12 @@ const ScenarioViewer = () => {
   // For Download data button
   const [downloadToken, setDownloadToken] = useState("");
 
+  // Reset tabs if users change Project ID, Vs30, Z values or Location
+  useEffect(() => {
+    setProjectScenarioGetClick(null);
+    setShowErrorMessage({ isError: false, errorCode: null });
+  }, [projectId, projectVS30, projectLocation, projectZ1p0, projectZ2p5]);
+
   // Get Scenario data
   useEffect(() => {
     const abortController = new AbortController();
@@ -89,12 +95,6 @@ const ScenarioViewer = () => {
       abortController.abort();
     };
   }, [projectScenarioGetClick]);
-
-  // Reset tabs if users change Project ID, Vs30, Z values or Location
-  useEffect(() => {
-    setProjectScenarioGetClick(null);
-    setShowErrorMessage({ isError: false, errorCode: null });
-  }, [projectId, projectVS30, projectLocation, projectZ1p0, projectZ2p5]);
 
   const updateScenarioData = (data) => {
     setProjectScenarioData(data);

--- a/frontend/src/components/Project/SeismicHazard/DisaggregationSection.js
+++ b/frontend/src/components/Project/SeismicHazard/DisaggregationSection.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect, Fragment } from "react";
+import React, { useState, useContext, Fragment } from "react";
 
 import { v4 as uuidv4 } from "uuid";
 
@@ -13,19 +13,11 @@ const DisaggregationSection = () => {
     projectSelectedIM,
     projectSelectedIMPeriod,
     projectSelectedIMComponent,
-    projectSelectedDisagRP,
     setProjectSelectedDisagRP,
     setProjectDisaggGetClick,
   } = useContext(GlobalContext);
 
   const [localSelectedRP, setLocalSelectedRP] = useState(null);
-
-  // Reset local variable to null when global changed to null (Reset)
-  useEffect(() => {
-    if (projectSelectedDisagRP === null) {
-      setLocalSelectedRP(null);
-    }
-  }, [projectSelectedDisagRP]);
 
   const getDisagg = () => {
     setProjectSelectedDisagRP(localSelectedRP["value"]);

--- a/frontend/src/components/Project/SeismicHazard/HazardCurveSection.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardCurveSection.js
@@ -9,7 +9,6 @@ import { IMCustomSelect, GuideTooltip } from "components/common";
 
 const HazardCurveSection = () => {
   const {
-    projectSelectedIM,
     setProjectSelectedIM,
     setProjectSelectedIMPeriod,
     setProjectSelectedIMComponent,
@@ -25,13 +24,6 @@ const HazardCurveSection = () => {
 
   const [periodOptions, setPeriodOptions] = useState([]);
   const [componentOptions, setComponentOptions] = useState([]);
-
-  // Reset local variable to null when global changed to null (Reset)
-  useEffect(() => {
-    if (projectSelectedIM === null) {
-      setLocalSelectedIM(null);
-    }
-  }, [projectSelectedIM]);
 
   // When local IM gets changed, update the global instantly so can do disaggregation without getting Hazard Curve data
   useEffect(() => {

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerDisaggregation.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerDisaggregation.js
@@ -39,6 +39,7 @@ const HazadViewerDisaggregation = () => {
     projectSelectedIMComponent,
     projectSelectedDisagRP,
     setProjectSelectedDisagRP,
+    projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   // For data fetcher
@@ -70,6 +71,24 @@ const HazadViewerDisaggregation = () => {
     src: null,
   });
 
+  // Reset tabs if users change project id, project vs30, project location or project im
+  useEffect(() => {
+    if (projectSiteSelectionGetClick !== null) {
+      setShowSpinnerDisaggEpsilon(false);
+      setShowPlotDisaggEpsilon(false);
+
+      setShowSpinnerDisaggFault(false);
+      setShowPlotDisaggFault(false);
+
+      setShowContribTable(false);
+      setShowSpinnerContribTable(false);
+
+      setProjectDisaggGetClick(null);
+
+      setProjectSelectedDisagRP(null);
+    }
+  }, [projectSiteSelectionGetClick]);
+
   // Replace the .(dot) to p for filename
   useEffect(() => {
     if (projectSelectedIM !== null && projectSelectedIM !== "pSA") {
@@ -83,22 +102,6 @@ const HazadViewerDisaggregation = () => {
       );
     }
   }, [projectSelectedIM, projectSelectedIMPeriod]);
-
-  // Reset tabs if users change project id, project vs30, project location or project im
-  useEffect(() => {
-    setShowSpinnerDisaggEpsilon(false);
-    setShowPlotDisaggEpsilon(false);
-
-    setShowSpinnerDisaggFault(false);
-    setShowPlotDisaggFault(false);
-
-    setShowContribTable(false);
-    setShowSpinnerContribTable(false);
-
-    setProjectDisaggGetClick(null);
-
-    setProjectSelectedDisagRP(null);
-  }, [projectId, projectVS30, projectLocation]);
 
   // Get hazard disagg data
   useEffect(() => {

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerDisaggregation.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerDisaggregation.js
@@ -71,7 +71,7 @@ const HazadViewerDisaggregation = () => {
     src: null,
   });
 
-  // Reset tabs if users change project id, project vs30, project location or project im
+  // Reset tabs if users click Get button from Site Selection
   useEffect(() => {
     if (projectSiteSelectionGetClick !== null) {
       setShowSpinnerDisaggEpsilon(false);

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
@@ -42,6 +42,7 @@ const HazardViewerHazardCurve = () => {
     projectSelectedIMPeriod,
     projectSelectedIMComponent,
     setProjectSelectedIMPeriod,
+    projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   // For Fetching Hazard data
@@ -66,6 +67,17 @@ const HazardViewerHazardCurve = () => {
   const [downloadToken, setDownloadToken] = useState("");
   const [filteredSelectedIM, setFilteredSelectedIM] = useState("");
 
+  // Reset tabs if users click Get button from Site Selection
+  useEffect(() => {
+    if (projectSiteSelectionGetClick !== null) {
+      setShowSpinnerHazard(false);
+      setShowPlotHazard(false);
+      setProjectHazardCurveGetClick(null);
+      setProjectSelectedIM(null);
+      setProjectSelectedIMPeriod(null);
+    }
+  }, [projectSiteSelectionGetClick]);
+
   // Replace the .(dot) to p for filename
   useEffect(() => {
     if (projectSelectedIM !== null && projectSelectedIM !== "pSA") {
@@ -79,15 +91,6 @@ const HazardViewerHazardCurve = () => {
       );
     }
   }, [projectSelectedIM, projectSelectedIMPeriod]);
-
-  // Reset tabs if users change Project ID, Vs30 or Location
-  useEffect(() => {
-    setShowSpinnerHazard(false);
-    setShowPlotHazard(false);
-    setProjectHazardCurveGetClick(null);
-    setProjectSelectedIM(null);
-    setProjectSelectedIMPeriod(null);
-  }, [projectId, projectVS30, projectLocation]);
 
   // Get hazard curve data
   useEffect(() => {

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -33,6 +33,7 @@ const HazardViewerUHS = () => {
     projectSelectedIMComponent,
     projectUHSGetClick,
     setProjectUHSGetClick,
+    projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   // For UHS data fetcher
@@ -56,13 +57,15 @@ const HazardViewerUHS = () => {
   const [localSelectedRP, setLocalSelectedRP] = useState(null);
   const [uhsRPOptions, setUHSRPOptions] = useState([]);
 
-  // Reset tabs if users change project id, project location or project vs30
+  // Reset tabs if users click Get button from Site Selection
   useEffect(() => {
-    setShowPlotUHS(false);
-    setShowSpinnerUHS(false);
-    setProjectSelectedUHSRP([]);
-    setProjectUHSGetClick(null);
-  }, [projectId, projectLocation, projectVS30]);
+    if (projectSiteSelectionGetClick !== null) {
+      setShowPlotUHS(false);
+      setShowSpinnerUHS(false);
+      setProjectSelectedUHSRP([]);
+      setProjectUHSGetClick(null);
+    }
+  }, [projectSiteSelectionGetClick]);
 
   // Setting variables for the selected RP and RP options
   useEffect(() => {

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -125,13 +125,7 @@ const HazardViewerUHS = () => {
   }, [projectUHSGetClick]);
 
   // Create an array of selected RPs
-  const getSelectedRP = () => {
-    let tempArray = [];
-
-    projectSelectedUHSRP.forEach((RP) => tempArray.push(RP.value));
-
-    return tempArray;
-  };
+  const getSelectedRP = () => projectSelectedUHSRP.map((RP) => RP.value);
 
   /* 
     Filter the UHSData with selected RPs to display

--- a/frontend/src/components/Project/SeismicHazard/UHSSection.js
+++ b/frontend/src/components/Project/SeismicHazard/UHSSection.js
@@ -13,23 +13,26 @@ import { GuideTooltip } from "components/common";
 const UHSSection = () => {
   const {
     projectUHSRPs,
-    projectSelectedUHSRP,
     setProjectSelectedUHSRP,
     setProjectUHSGetClick,
     projectIMs,
+    projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   const animatedComponents = makeAnimated();
-  const [localRPs, setLocalRPs] = useState([]);
 
-  const options = createSelectArray(projectUHSRPs);
+  const [localRPs, setLocalRPs] = useState([]);
+  const [rpOptions, setRPOptions] = useState([]);
 
   // Reset local variable to empty array when global changed to empty array (Reset)
   useEffect(() => {
-    if (projectSelectedUHSRP.length === 0) {
-      setLocalRPs([]);
+    setLocalRPs([]);
+    if (projectUHSRPs.length !== 0) {
+      setRPOptions(createSelectArray(projectUHSRPs));
+    } else {
+      setRPOptions([]);
     }
-  }, [projectSelectedUHSRP]);
+  }, [projectSiteSelectionGetClick]);
 
   const getUHS = () => {
     setProjectSelectedUHSRP(localRPs);
@@ -58,11 +61,11 @@ const UHSSection = () => {
             closeMenuOnSelect={false}
             components={animatedComponents}
             isMulti
-            placeholder={options.length === 0 ? "Not available" : "Select..."}
+            placeholder={rpOptions.length === 0 ? "Not available" : "Select..."}
             value={localRPs.length === 0 ? [] : localRPs}
             onChange={(value) => setLocalRPs(value || [])}
-            options={options}
-            isDisabled={options.length === 0 || isPSANotInIMList(projectIMs)}
+            options={rpOptions}
+            isDisabled={rpOptions.length === 0 || isPSANotInIMList(projectIMs)}
             menuPlacement="auto"
             menuPortalTarget={document.body}
           />

--- a/frontend/src/components/Project/SiteSelection/SiteSelectionForm.js
+++ b/frontend/src/components/Project/SiteSelection/SiteSelectionForm.js
@@ -242,9 +242,9 @@ const SiteSelectionForm = () => {
     setProjectVS30(localVS30["value"]);
     setProjectZ1p0(localZs["value"]["Z1.0"]);
     setProjectZ2p5(localZs["value"]["Z2.5"]);
-    setProjectSiteSelectionGetClick(uuidv4());
     setProjectLat(renderSigfigs(lat, CONSTANTS.APP_UI_SIGFIGS));
     setProjectLng(renderSigfigs(lng, CONSTANTS.APP_UI_SIGFIGS));
+    setProjectSiteSelectionGetClick(uuidv4());
   };
 
   /*

--- a/frontend/src/components/Project/SiteSelection/SiteSelectionForm.js
+++ b/frontend/src/components/Project/SiteSelection/SiteSelectionForm.js
@@ -66,6 +66,17 @@ const SiteSelectionForm = () => {
   const [lat, setLat] = useState("");
   const [lng, setLng] = useState("");
 
+  // Reset dropdowns when Project ID gets changed
+  useEffect(() => {
+    if (localProjectId !== null) {
+      setLocalLocation(null);
+      setLocalVS30(null);
+      setLocationOptions([]);
+      setVs30Options([]);
+      setZOptions([]);
+    }
+  }, [localProjectId]);
+
   // Getting Project IDs
   useEffect(() => {
     const abortController = new AbortController();
@@ -194,17 +205,6 @@ const SiteSelectionForm = () => {
       }
     }
   }, [localVS30]);
-
-  // Reset dropdowns when Project ID gets changed
-  useEffect(() => {
-    if (localProjectId !== null) {
-      setLocalLocation(null);
-      setLocalVS30(null);
-      setLocationOptions([]);
-      setVs30Options([]);
-      setZOptions([]);
-    }
-  }, [localProjectId]);
 
   // Get GMS IDs
   useEffect(() => {

--- a/frontend/src/components/Project/SiteSelection/SiteSelectionViewer.js
+++ b/frontend/src/components/Project/SiteSelection/SiteSelectionViewer.js
@@ -26,7 +26,6 @@ const SiteSelectionViewer = () => {
     projectZ2p5,
     projectLocationCode,
     projectSiteSelectionGetClick,
-    setProjectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
   const [showSpinner, setShowSpinner] = useState(false);
@@ -38,16 +37,6 @@ const SiteSelectionViewer = () => {
 
   const [regionalMap, setRegionalMap] = useState(null);
   const [vs30Map, setVS30Map] = useState(null);
-
-  /*
-    Reset when it first renders
-    E.g. change tab between Projects to Hazard Analyis
-  */
-  useEffect(() => {
-    setShowImages(false);
-    setShowSpinner(false);
-    setProjectSiteSelectionGetClick(null);
-  }, []);
 
   // Get Context/Vs30 maps
   useEffect(() => {

--- a/frontend/src/components/common/CustomSelect.js
+++ b/frontend/src/components/common/CustomSelect.js
@@ -94,16 +94,10 @@ const CustomSelect = ({
 
       <Select
         ref={selectInputRef}
-        placeholder={
-          localOptions.length === 0
-            ? placeholder
-            : "Select..."
-        }
+        placeholder={localOptions.length === 0 ? placeholder : "Select..."}
         onChange={(e) => setSelect(e)}
         options={localOptions}
-        isDisabled={
-          localOptions.length === 0
-        }
+        isDisabled={localOptions.length === 0}
         menuPlacement="auto"
         menuPortalTarget={document.body}
       />

--- a/frontend/src/utils/Utils.js
+++ b/frontend/src/utils/Utils.js
@@ -134,12 +134,10 @@ export const sortDuplicateYRange = (givenArr) => {
   },...]
 */
 export const createSelectArray = (options) => {
-  let selectOptions = options.map((option) => ({
+  return options.map((option) => ({
     value: option,
     label: option,
   }));
-
-  return selectOptions;
 };
 
 /* 
@@ -161,12 +159,10 @@ export const createProjectIDArray = (options) => {
   Specially made for Projects Vs30 - label to contain unit, m/s
 */
 export const createVs30Array = (options) => {
-  let selectOptions = options.map((option) => ({
+  return options.map((option) => ({
     value: option,
     label: `${option} m/s`,
   }));
-
-  return selectOptions;
 };
 
 /* 

--- a/frontend/src/views/Project.js
+++ b/frontend/src/views/Project.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useContext } from "react";
+import React, { Fragment, useContext, useEffect } from "react";
 
 import { Tabs, Tab } from "react-bootstrap";
 import { GlobalContext } from "context";
@@ -14,7 +14,30 @@ import { HazardForm, HazardViewer } from "components/Project/SeismicHazard";
 import { ScenarioForm, ScenarioViewer } from "components/Project/Scenarios";
 
 const Project = () => {
-  const { projectId, projectLocation, projectVS30 } = useContext(GlobalContext);
+  const {
+    projectId,
+    projectLocation,
+    projectVS30,
+    setProjectSiteSelectionGetClick,
+    setProjectHazardCurveGetClick,
+    setProjectDisaggGetClick,
+    setProjectUHSGetClick,
+    setProjectGMSGetClick,
+    setProjectScenarioGetClick,
+  } = useContext(GlobalContext);
+
+  useEffect(() => {
+    console.log("User accessed to the /Projects tab");
+    return () => {
+      console.log("User went to somewhere else, no longer on /Projects tab");
+      setProjectSiteSelectionGetClick(null);
+      setProjectHazardCurveGetClick(null);
+      setProjectDisaggGetClick(null);
+      setProjectUHSGetClick(null);
+      setProjectGMSGetClick(null);
+      setProjectScenarioGetClick(null);
+    };
+  }, []);
 
   const invalidTab = () => {
     return (

--- a/frontend/src/views/Project.js
+++ b/frontend/src/views/Project.js
@@ -26,10 +26,9 @@ const Project = () => {
     setProjectScenarioGetClick,
   } = useContext(GlobalContext);
 
+  // Reset some global variables when this component gets unmounted
   useEffect(() => {
-    console.log("User accessed to the /Projects tab");
     return () => {
-      console.log("User went to somewhere else, no longer on /Projects tab");
       setProjectSiteSelectionGetClick(null);
       setProjectHazardCurveGetClick(null);
       setProjectDisaggGetClick(null);


### PR DESCRIPTION
# Fix reset states

## Main changes - Reset the `useState` hook at the right timing
From
```javascript
/*
    Reset when it first renders
    E.g. change tab between Projects to Hazard Analysis
  */
  useEffect(() => {
    setShowImages(false);
    setShowSpinner(false);
    setProjectSiteSelectionGetClick(null);
  }, []);
```
To
```javascript
// Reset some global variables when this component gets unmounted
  useEffect(() => {
    return () => {
      setProjectSiteSelectionGetClick(null);
      setProjectHazardCurveGetClick(null);
      setProjectDisaggGetClick(null);
      setProjectUHSGetClick(null);
      setProjectGMSGetClick(null);
      setProjectScenarioGetClick(null);
    };
  }, []);
```
Code we used to have, theoretically made sense as if a user comes back to Project tab from Hazard Analysis or vice versa, it's an initial render which will trigger that `useEffect(() => {}, [])`. However, because the `useState` hook is asynchronous, `setProjectSiteSelectionGetClick(null);` does not change `projectSiteSelectionGetClick` to null instantly so the app will try to fetch some data but then the app does not have some arguments to go with requests.

This is what happens by switching from Project to Hazard analysis and coming back to Project.
![image](https://user-images.githubusercontent.com/7849113/145326450-e99ad8c6-4664-4a0c-a02b-51bd027fa1ef.png)
and by changing the timing. So, when a user escapes the Projects tab, the following states(global variables) set back to null, so by the time they come back to Projects, nothing will happen.
```javascript
setProjectSiteSelectionGetClick(null);
setProjectHazardCurveGetClick(null);
setProjectDisaggGetClick(null);
setProjectUHSGetClick(null);
setProjectGMSGetClick(null);
setProjectScenarioGetClick(null);
```

## Reset `useStates` when user clicks a get button
Instead of checking multiple variables for the `useEffect` hook, check only one variable.
For instance, the following code gets executed when one of the values(projected, projectVS30, projectLocation) gets changed. However, those are all global variables and they only get changed when a user clicks a get button from the Site Selection tab.
Also, by clicking the get button from the Site Selection, all the values get changed and it causes the app to trigger this useEffect three times.
```javascript
useEffect(() => {
    setShowSpinnerHazard(false);
    setShowPlotHazard(false);
    setProjectHazardCurveGetClick(null);
    setProjectSelectedIM(null);
    setProjectSelectedIMPeriod(null);
  }, [projectId, projectVS30, projectLocation]);
```
Hence, watch the `GetClick` value instead and it only execute `useEffect` hook once a user clicks the Get button from the Site Selection and only if it is not a `null`.
```javascript
// Reset tabs if users click Get button from Site Selection
  useEffect(() => {
    if (projectSiteSelectionGetClick !== null) {
      setShowSpinnerHazard(false);
      setShowPlotHazard(false);
      setProjectHazardCurveGetClick(null);
      setProjectSelectedIM(null);
      setProjectSelectedIMPeriod(null);
    }
  }, [projectSiteSelectionGetClick]);
```

## Minor changes
- Change the order of `useEffect`, any `useEffect` to reset variables will now be at the top of the component. (Still below any `useState`)
- Changed a way of checking the size of the array from `a !== []` to `a.length !== 0` as with JS, `[] !== []` will always be true.
    - Speaking of checking the size of the array, we can perhaps think of replacing `a.length !== 0` to `a.length > 0` as the length of the array cannot be negative and we want them to be not empty, which is always greater than 0 but I haven't pushed that far within this PR.
- When a user clicks a Get within the Scenario tab, the selected scenarios will be removed.

