### PR TITLE
Updating weights configs

### DIFF
--- a/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/21p10.yaml
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/21p10.yaml
@@ -48,6 +48,18 @@ ACTIVE_SHALLOW:
       - BSSA_14
       - CB_14
       - CY_14
+  CAV:
+    geom:
+      - CB_10
+  AI:
+    geom:
+      - CB_12
+  Ds575:
+    geom:
+      - AS_16
+  Ds595:
+    geom:
+      - AS_16
 VOLCANIC:
   PGV:
     geom:
@@ -58,6 +70,18 @@ VOLCANIC:
   pSA:
     geom:
       - Br_10
+  CAV:
+    geom:
+      - CB_10 # These are only for shallow crustal in lieu of a more appropriate model
+  AI:
+    geom:
+      - CB_12 # These are only for shallow crustal in lieu of a more appropriate model
+  Ds575:
+    geom:
+      - AS_16 # These are only for shallow crustal in lieu of a more appropriate model
+  Ds595:
+    geom:
+      - AS_16 # These are only for shallow crustal in lieu of a more appropriate model
 SUBDUCTION_SLAB:
   PGV:
     geom:
@@ -84,6 +108,18 @@ SUBDUCTION_SLAB:
       - AG_20_NZ
       - K_20
       - K_20_NZ
+  CAV:
+    geom:
+      - CB_10 # These are only for shallow crustal in lieu of a more appropriate model
+  AI:
+    geom:
+      - CB_12 # These are only for shallow crustal in lieu of a more appropriate model
+  Ds575:
+    geom:
+      - AS_16 # These are only for shallow crustal in lieu of a more appropriate model
+  Ds595:
+    geom:
+      - AS_16 # These are only for shallow crustal in lieu of a more appropriate model
 SUBDUCTION_INTERFACE:
   PGV:
     geom:
@@ -100,7 +136,6 @@ SUBDUCTION_INTERFACE:
       - AG_20_NZ
       - K_20
       - K_20_NZ
-
   pSA:
     geom:
       - ZA_06
@@ -111,3 +146,15 @@ SUBDUCTION_INTERFACE:
       - AG_20_NZ
       - K_20
       - K_20_NZ
+  CAV:
+    geom:
+      - CB_10 # These are only for shallow crustal in lieu of a more appropriate model
+  AI:
+    geom:
+      - CB_12 # These are only for shallow crustal in lieu of a more appropriate model
+  Ds575:
+    geom:
+      - AS_16 # These are only for shallow crustal in lieu of a more appropriate model
+  Ds595:
+    geom:
+      - AS_16 # These are only for shallow crustal in lieu of a more appropriate model

--- a/tools/gmhazard_scripts/ensemble_creation/gmm_weights_21p10.yaml
+++ b/tools/gmhazard_scripts/ensemble_creation/gmm_weights_21p10.yaml
@@ -1,3 +1,12 @@
+CAV:
+        !!python/tuple [ACTIVE_SHALLOW, SUBDUCTION_INTERFACE, SUBDUCTION_SLAB, VOLCANIC]:
+                CB_10: 1
+AI:
+        !!python/tuple [ACTIVE_SHALLOW, SUBDUCTION_INTERFACE, SUBDUCTION_SLAB, VOLCANIC]:
+                CB_12: 1
+!!python/tuple [Ds575, Ds595]:
+        !!python/tuple [ACTIVE_SHALLOW, SUBDUCTION_INTERFACE, SUBDUCTION_SLAB, VOLCANIC]:
+                AS_16: 1
 !!python/tuple [pSA, PGA]:
         ACTIVE_SHALLOW:
                 Br_10: 0.2
@@ -5,11 +14,22 @@
                 BSSA_14: 0.2
                 CB_14: 0.2
                 CY_14: 0.2
-        SUBDUCTION:
+        SUBDUCTION_INTERFACE:
                 ZA_06: 0.1
+                BCH_16: 0.05
+                A_18: 0.1
+                P_20: 0.3
+                AG_20: 0.075
+                AG_20_NZ: 0.075
+                K_20: 0.1
+                K_20_NZ: 0.2
+        SUBDUCTION_SLAB:
+                ZA_06: 0.1
+                BCH_16: 0.05
+                A_18: 0.1
                 P_20: 0.2
-                AG_20: 0.175
-                AG_20_NZ: 0.175
+                AG_20: 0.1
+                AG_20_NZ: 0.1
                 K_20: 0.175
                 K_20_NZ: 0.175
         VOLCANIC:

--- a/tools/gmhazard_scripts/ensemble_creation/gmm_weights_21p10.yaml
+++ b/tools/gmhazard_scripts/ensemble_creation/gmm_weights_21p10.yaml
@@ -14,22 +14,11 @@ AI:
                 BSSA_14: 0.2
                 CB_14: 0.2
                 CY_14: 0.2
-        SUBDUCTION_INTERFACE:
+        SUBDUCTION:
                 ZA_06: 0.1
-                BCH_16: 0.05
-                A_18: 0.1
-                P_20: 0.3
-                AG_20: 0.075
-                AG_20_NZ: 0.075
-                K_20: 0.1
-                K_20_NZ: 0.2
-        SUBDUCTION_SLAB:
-                ZA_06: 0.1
-                BCH_16: 0.05
-                A_18: 0.1
                 P_20: 0.2
-                AG_20: 0.1
-                AG_20_NZ: 0.1
+                AG_20: 0.175
+                AG_20_NZ: 0.175
                 K_20: 0.175
                 K_20_NZ: 0.175
         VOLCANIC:


### PR DESCRIPTION
# Updating weights configs

Updating the missing IM and weights.

- Checked with Empirical Engine's weights - [Empirical Engine](https://github.com/ucgmsim/Empirical_Engine/blob/master/empirical/util/gmm_weights.yaml)
- Brought back the following IMs from the old config file
    - CAV
    - AI
    - Ds575
    - Ds595