### PR TITLE
Allow for no directivity calculation

### DIFF
--- a/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
@@ -155,9 +155,10 @@ def load_args():
     )
     parser.add_argument(
         "--no_directivity",
-        action="store_true",
-        help="Boolean to calculate directivity or not for the sites",
-        default=False,
+        action="store_false",
+        dest="directivity",
+        help="Flag to turn off directivity calculation",
+        default=True,
     )
 
     args = parser.parse_args()
@@ -215,7 +216,7 @@ def main():
         fault_df = pd.DataFrame(sorted(nhm_data.keys()), columns=["fault_name"])
 
         site_source_distance_data, directivity_data = compute_site_source_distances(
-            stations.to_numpy(), nhm_data, calculate_directivity=not args.no_directivity
+            stations.to_numpy(), nhm_data, calculate_directivity=args.directivity
         )
     else:
         fault_data_ffp = os.path.abspath(args.gcmt_ffp)

--- a/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
@@ -153,6 +153,9 @@ def load_args():
         help="List of stations for a specific domain. Source to site distances "
         "will be calculated for all stations in the station_file.",
     )
+    parser.add_argument(
+        "--directivity", type=bool, help="Boolean to calculate directivity or not for the sites", default=True
+    )
 
     args = parser.parse_args()
 
@@ -209,7 +212,7 @@ def main():
         fault_df = pd.DataFrame(sorted(nhm_data.keys()), columns=["fault_name"])
 
         site_source_distance_data, directivity_data = compute_site_source_distances(
-            stations.to_numpy(), nhm_data
+            stations.to_numpy(), nhm_data, calculate_directivity=args.directivity
         )
     else:
         fault_data_ffp = os.path.abspath(args.gcmt_ffp)

--- a/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
@@ -154,10 +154,10 @@ def load_args():
         "will be calculated for all stations in the station_file.",
     )
     parser.add_argument(
-        "--directivity",
-        type=lambda x: (str(x).lower() == 'true'),
+        "--no_directivity",
+        action="store_true",
         help="Boolean to calculate directivity or not for the sites",
-        default=True,
+        default=False,
     )
 
     args = parser.parse_args()
@@ -215,7 +215,7 @@ def main():
         fault_df = pd.DataFrame(sorted(nhm_data.keys()), columns=["fault_name"])
 
         site_source_distance_data, directivity_data = compute_site_source_distances(
-            stations.to_numpy(), nhm_data, calculate_directivity=args.directivity
+            stations.to_numpy(), nhm_data, calculate_directivity=not args.no_directivity
         )
     else:
         fault_data_ffp = os.path.abspath(args.gcmt_ffp)

--- a/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/calc_distances_flt.py
@@ -154,7 +154,10 @@ def load_args():
         "will be calculated for all stations in the station_file.",
     )
     parser.add_argument(
-        "--directivity", type=bool, help="Boolean to calculate directivity or not for the sites", default=True
+        "--directivity",
+        type=lambda x: (str(x).lower() == 'true'),
+        help="Boolean to calculate directivity or not for the sites",
+        default=True,
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
In `calc_distances_flt` there was no option to allow for a False entry to disable calculating directivity.

Noticed when generating spatial hazard projects calculating the site source db was taking too long.