### PR TITLE
HOTFIX: calc_emp_flt module - the parse arg

### DIFF
--- a/calculation/gmhazard_calc/gmhazard_calc/dbs/SiteSourceDB.py
+++ b/calculation/gmhazard_calc/gmhazard_calc/dbs/SiteSourceDB.py
@@ -7,6 +7,10 @@ from gmhazard_calc import constants as const
 from .BaseDB import BaseDB, check_open
 
 
+STATION_DIRECTIVITY = "/directivity/station"
+STATION_DISTANCE = "/distances/station"
+
+
 class SiteSourceDB(BaseDB):
     """Class that handles retrieving/writing data with a SiteSourceDB"""
 
@@ -51,11 +55,11 @@ class SiteSourceDB(BaseDB):
             self._keys_cache = set(self._db.keys())
 
         return [
-            # removes the '/distance/station_' at the start
+            # removes the '/distances/station_' at the start
             # of the key to retrieve the station name
             cur_key.split("_", maxsplit=1)[-1]
             for cur_key in self._keys_cache
-            if cur_key.startswith("/distance")
+            if cur_key.startswith(STATION_DISTANCE)
         ]
 
     @check_open
@@ -223,8 +227,8 @@ class SiteSourceDB(BaseDB):
 
     @staticmethod
     def station_distance_h5_key(name):
-        return f"/distances/station_{name}"
+        return f"{STATION_DISTANCE}_{name}"
 
     @staticmethod
     def station_directivity_h5_key(name):
-        return f"/directivity/station_{name}"
+        return f"{STATION_DIRECTIVITY}_{name}"

--- a/calculation/gmhazard_calc/gmhazard_calc/dbs/SiteSourceDB.py
+++ b/calculation/gmhazard_calc/gmhazard_calc/dbs/SiteSourceDB.py
@@ -51,6 +51,8 @@ class SiteSourceDB(BaseDB):
             self._keys_cache = set(self._db.keys())
 
         return [
+            # removes the '/distance/station_' at the start
+            # of the key to retrieve the station name
             cur_key.split("_", maxsplit=1)[-1]
             for cur_key in self._keys_cache
             if cur_key.startswith("/distance")

--- a/calculation/gmhazard_calc/gmhazard_calc/dbs/SiteSourceDB.py
+++ b/calculation/gmhazard_calc/gmhazard_calc/dbs/SiteSourceDB.py
@@ -51,7 +51,7 @@ class SiteSourceDB(BaseDB):
             self._keys_cache = set(self._db.keys())
 
         return [
-            cur_key.split("_")[-1]
+            cur_key.split("_", maxsplit=1)[-1]
             for cur_key in self._keys_cache
             if cur_key.startswith("/distance")
         ]

--- a/tools/gmhazard_scripts/db_creation/empirical_db/calc_emp_flt.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/calc_emp_flt.py
@@ -211,8 +211,9 @@ def parse_args():
     parser.add_argument(
         "--rupture_lookup",
         "-rl",
-        help="flag to run rupture lookup function when creating the db",
+        action="store_true",
         default=False,
+        help="flag to run rupture lookup function when creating the db",
     )
     parser.add_argument(
         "--n-procs", type=int, help="Number of processes to use", default=1
@@ -220,7 +221,6 @@ def parse_args():
     parser.add_argument(
         "--no-directivity",
         action="store_true",
-        type=bool,
         default=False,
         help="Disable adding directivity adjustment",
     )


### PR DESCRIPTION
# HOTFIX: calc_emp_flt module - the parse arg

Got the following error message
```python
TypeError: __init__() got an unexpected keyword argument 'type'
```
I don't think that type is valid for boolean type and add action to `rupture_lookup` as well.

Hence, I used one of the [options](https://www.pythonpool.com/python-argparse-boolean/), the second one.
