### PR TITLE
New calc_emp_ds

### DIFF
--- a/tools/gmhazard_scripts/db_creation/empirical_db/calc_emp_ds.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/calc_emp_ds.py
@@ -122,6 +122,8 @@ def calculate_ds(
             for i, n_rows, site, n_mp_proc in iter(
                 lambda: comm.sendrecv(value, dest=master), StopIteration
             ):
+                print("IN CALC_EMP_DS")
+                print(site)
                 comm_time = time.perf_counter() - s_time
                 wait_time += comm_time
                 if distance_store.has_station_data(site.name):

--- a/tools/gmhazard_scripts/db_creation/empirical_db/calc_emp_ds.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/calc_emp_ds.py
@@ -122,8 +122,6 @@ def calculate_ds(
             for i, n_rows, site, n_mp_proc in iter(
                 lambda: comm.sendrecv(value, dest=master), StopIteration
             ):
-                print("IN CALC_EMP_DS")
-                print(site)
                 comm_time = time.perf_counter() - s_time
                 wait_time += comm_time
                 if distance_store.has_station_data(site.name):

--- a/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/21p10.yaml
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/21p10.yaml
@@ -91,8 +91,6 @@ SUBDUCTION_SLAB:
   PGA:
     geom:
       - ZA_06
-      - BCH_16
-      - A_18  # ZA06 or BCH16
       - P_20
       - AG_20
       - AG_20_NZ
@@ -101,8 +99,6 @@ SUBDUCTION_SLAB:
   pSA:
     geom:
       - ZA_06
-      - BCH_16
-      - A_18  # ZA06 or BCH16
       - P_20
       - AG_20
       - AG_20_NZ
@@ -129,8 +125,6 @@ SUBDUCTION_INTERFACE:
   PGA:
     geom:
       - ZA_06
-      - BCH_16
-      - A_18  # ZA06 or BCH16
       - P_20
       - AG_20
       - AG_20_NZ
@@ -139,8 +133,6 @@ SUBDUCTION_INTERFACE:
   pSA:
     geom:
       - ZA_06
-      - BCH_16
-      - A_18  # ZA06 or BCH16
       - P_20
       - AG_20
       - AG_20_NZ

--- a/tools/gmhazard_scripts/db_creation/empirical_db/new_calc_emp_ds.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/new_calc_emp_ds.py
@@ -1,0 +1,134 @@
+import argparse
+import math
+import time
+import threading
+
+import pandas as pd
+
+
+import common
+import gmhazard_calc as gc
+from empirical.util import empirical_factory
+
+
+def calculate_ds(
+    background_sources_ffp,
+    site_source_db_ffp,
+    vs30_ffp,
+    z_ffp,
+    ims,
+    psa_periods,
+    output_dir,
+    model_dict_ffp,
+    suffix=None,
+):
+    """
+    Calculate Empirical values for every site-fault pairing in the provided site_source_db.
+
+    Pairs the station name with the vs30 value in the provided vs30 file. Only sites that have vs30 values will be calculated.
+
+    Saves all IM values (median and sigma) for all ims specified to the imdb_path in pandas h5 format
+
+    :return: None
+    """
+    wait_time = 0.0
+    # Setting up some data
+    nhm_data = gc.utils.ds_nhm_to_rup_df(background_sources_ffp)
+    rupture_df = pd.DataFrame(nhm_data["rupture_name"])
+    imdb_dict, stations_calculated = common.open_imdbs(
+        model_dict_ffp,
+        output_dir,
+        gc.constants.SourceType.distributed,
+        suffix=suffix,
+    )
+    model_dict = empirical_factory.read_model_dict(model_dict_ffp)
+
+    imdb_dict_copy = {key: None for key in imdb_dict.keys()}
+    with gc.dbs.SiteSourceDB(site_source_db_ffp) as distance_store:
+        fault_df, n_stations, site_df, _ = common.get_work(
+            distance_store, vs30_ffp, z_ffp, None, 1, stations_calculated
+        )
+        for _, site in site_df.iterrows():
+            max_dist = common.get_max_dist_zfac_scaled(site)
+
+            value = (
+                common.new_calculate_emp_site(
+                    ims,
+                    psa_periods,
+                    imdb_dict_copy,
+                    fault_df,
+                    rupture_df,
+                    distance_store,
+                    nhm_data,
+                    site.vs30,
+                    site.z1p0 if hasattr(site, "z1p0") else None,
+                    site.z2p5 if hasattr(site, "z2p5") else None,
+                    site.name,
+                    model_dict,
+                    max_dist,
+                    dist_filter_by_mag=True,
+                    return_vals=True,
+                    use_directivity=False,
+                    n_procs=1,
+                ),
+                site.name,
+            )
+
+            breakpoint()
+
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("background_txt", help="background txt file")
+    parser.add_argument("site_source_db")
+    parser.add_argument("vs30_file")
+    parser.add_argument("output_dir")
+    parser.add_argument(
+        "--z-file",
+        help="File name of the Z data",
+    )
+    parser.add_argument(
+        "--periods",
+        default=common.PERIOD,
+        nargs="+",
+        help="Which pSA periods to calculate for",
+    )
+    parser.add_argument(
+        "--im",
+        default=common.IM_TYPE_LIST,
+        nargs="+",
+        help="Which IMs to calculate",
+        type=gc.im.IMType,
+    )
+    parser.add_argument(
+        "--model-dict",
+        help="model dictionary to specify which model to use for each tect-type",
+    )
+    parser.add_argument(
+        "--suffix",
+        "-s",
+        help="suffix for the end of the imdb files",
+        default=None,
+    )
+
+    return parser.parse_args()
+
+
+def calculate_emp_ds():
+    args = parse_args()
+    calculate_ds(
+        args.background_txt,
+        args.site_source_db,
+        args.vs30_file,
+        args.z_file,
+        args.im,
+        args.periods,
+        args.output_dir,
+        args.model_dict,
+        suffix=args.suffix,
+    )
+
+
+if __name__ == "__main__":
+    calculate_emp_ds()


### PR DESCRIPTION
# New calc_emp_ds

## 1. Still in progress, this PR is to give some updates on the progress.
## 2. For common.py, you don't have to worry about any changes before line 403 as I added some for debugging purposes and this is still a draft.
## 3. For the proper PR, there will be a proper docstring, comments, tidy up so on...
## 4. For now, not every model is supported due to the lack of interpolation.


## We originally planned to do something like
![Image from iOS (4)](https://user-images.githubusercontent.com/7849113/160524784-16b4cb13-bd1f-4488-9e9e-f45c0e924352.jpg)

## However,
But by looking at the existing script, I thought it would be simple to keep the current workflow.
For instance, 
1. function `write_result_to_db()` takes an arguments with `station_name` to store `im_data` per station.
2. common module's function, `get_work()` returns the number of stations that are not computed yet as a checkpoint.

## Main differences
### Remove MPI & use openquake_vectorized_wrapper
By removing MPI and adopting vectorized calculation, we don't have to go through every single rupture from `matching_df`, they can be calculated at once as our `vectorzied_oq_wrapper` is designed to work one multiple ruptures but with a single site.
(Any code below the comment, `# Adding missing columns` will make this `matching_df` contain three different types for OQ, such as Site, Distance and Rupture which is the form of the data frame we need to pass to our `vectorized_oq_wrapper`)

Also, because we for loop over `tect_type`, I chose the function `__new_process_rupture` to update one of its params, `fault_im_result_dict` instead of creating a new one every single run(Like the one with the previous version) as we do not need them anymore.

NEW
```python
fault_im_result_dict = {key: [] for key in imdb_dict.keys()}
    for tect_type in matching_df["tect_type"].unique():
        __new_process_rupture(
            matching_df,
            rupture_df,
            im_types,
            tect_type,
            tect_type_model_dict,
            directivity_df if use_directivity else None,
            psa_periods,
            keep_sigma_components,
            fault_im_result_dict,
            use_directivity,
        )
```

PREVIOUS
```python
results = p.starmap(
                __process_rupture,
                [
                    (
                        rupture,
                        site,
                        im_types,
                        tect_type_model_dict,
                        directivity_df.iloc[index] if use_directivity else None,
                        psa_periods,
                        keep_sigma_components,
                        {key: {} for key in imdb_dict.keys()},
                        use_directivity,
                    )
                    for index, rupture in matching_df.iterrows()
                ],
```

## Result
Six different combinations of Model and tect_type got created.
based on total 72 stations (24 stations * 3 different Vs30 values) finished in about 7.2 mins
![image](https://user-images.githubusercontent.com/7849113/160526287-a85157f6-50a3-4f3f-89de-b2fb79eeefa9.png)

### Br_10_ACTIVE_SHALLOW - IM_DATA at Arthurs_Pass_200_0p045_0p275
### Comparison between OLD and NEW PGA/PGA_mean
![image](https://user-images.githubusercontent.com/7849113/160526936-87ee357d-6f28-42d5-8eb7-6e88bd6d6d2c.png)

Interestingly indexes are all equal but some values are not, 9 values out of 38092 are not identical.
![image](https://user-images.githubusercontent.com/7849113/160527760-95520ae7-34c9-4e9d-b616-cdfda1fb0fb8.png)



