### PR TITLE
Investigate UHS and update the logic

### DIFF
--- a/apis/project_api/project_api/utils.py
+++ b/apis/project_api/project_api/utils.py
@@ -168,7 +168,8 @@ def load_uhs_data(results_dir: Path, rps: List[int]):
     ensemble = sc.uhs.EnsembleUHSResult.load(results_dir / f"uhs_{rps[0]}").ensemble
 
     uhs_results = [
-        sc.uhs.EnsembleUHSResult.load(results_dir / f"uhs_{rp}") for rp in rps
+        sc.uhs.EnsembleUHSResult.load(results_dir / f"uhs_{rp}", ensemble=ensemble)
+        for rp in rps
     ]
 
     nzs1170p5_results = [

--- a/calculation/gmhazard_calc/gmhazard_calc/gm_data/Ensemble.py
+++ b/calculation/gmhazard_calc/gmhazard_calc/gm_data/Ensemble.py
@@ -331,6 +331,7 @@ class Ensemble:
                 config_ffp=config_ffp,
                 use_im_data_cache=ensemble_params["use_im_data_cache"],
             )
+
         return cls(
             ensemble_params["name"],
             use_im_data_cache=ensemble_params["use_im_data_cache"],

--- a/calculation/gmhazard_calc/gmhazard_calc/gm_data/Ensemble.py
+++ b/calculation/gmhazard_calc/gmhazard_calc/gm_data/Ensemble.py
@@ -203,8 +203,8 @@ class Ensemble:
     @property
     def fault_rupture_df(self):
         return self.rupture_df_id.loc[
-               self.rupture_df_id.rupture_type == const.SourceType.fault.value, :
-               ]
+            self.rupture_df_id.rupture_type == const.SourceType.fault.value, :
+        ]
 
     def get_rupture_id_indices(self, rupture_ids: np.ndarray):
         """Gets the rupture_id_ix values for the given rupture_ids
@@ -240,7 +240,8 @@ class Ensemble:
 
         # Ensure that there are no duplicates in the lookup
         assert (
-            self._rupture_id_ix_lookup.index.unique().size == self._rupture_id_ix_lookup.size
+            self._rupture_id_ix_lookup.index.unique().size
+            == self._rupture_id_ix_lookup.size
         )
 
         # Get indices
@@ -248,7 +249,9 @@ class Ensemble:
 
     def get_rupture_ids(self, rupture_id_ind: np.ndarray):
         """Convert rupture id indices to rupture ids"""
-        result = self._rupture_id_ix_lookup.iloc[rupture_id_ind].index.values.astype(str)
+        result = self._rupture_id_ix_lookup.iloc[rupture_id_ind].index.values.astype(
+            str
+        )
 
         return result
 
@@ -328,7 +331,6 @@ class Ensemble:
                 config_ffp=config_ffp,
                 use_im_data_cache=ensemble_params["use_im_data_cache"],
             )
-
         return cls(
             ensemble_params["name"],
             use_im_data_cache=ensemble_params["use_im_data_cache"],

--- a/calculation/gmhazard_calc/gmhazard_calc/uhs/UHSResult.py
+++ b/calculation/gmhazard_calc/gmhazard_calc/uhs/UHSResult.py
@@ -228,15 +228,15 @@ class EnsembleUHSResult(BaseUHSResult):
         return data_dir
 
     @classmethod
-    def load(cls, data_dir: Path):
+    def load(cls, data_dir: Path, ensemble=None):
         """Loads a EnsembleUHSResult from a specified directory
         This also loads the BranchUHSResults and percentiles"""
         metadata, site_info, period_values, sa_values = cls._load_data(data_dir)
 
         with open(data_dir / cls.METADATA_FN, "r") as f:
             metadata = json.load(f)
-        ensemble = gm_data.Ensemble.load(metadata["ensemble_params"])
-
+        if ensemble is None:
+            ensemble = gm_data.Ensemble.load(metadata["ensemble_params"])
         # Load the branches, each directory in the branch_uhs folder
         branches_ffp = data_dir / "branch_uhs"
         branch_uhs = (


### PR DESCRIPTION
# Investigate UHS and update the logic

```python
# Within the Project API's utils module
uhs_results = [
        sc.uhs.EnsembleUHSResult.load(results_dir / f"uhs_{rp}") for rp in rps
    ]
# Within the gmhazard_calc's UHSResult module
@classmethod
    def load(cls, data_dir: Path):
        """Loads a EnsembleUHSResult from a specified directory
        This also loads the BranchUHSResults and percentiles"""
        metadata, site_info, period_values, sa_values = cls._load_data(data_dir)

        with open(data_dir / cls.METADATA_FN, "r") as f:
            metadata = json.load(f)
        ensemble = gm_data.Ensemble.load(metadata["ensemble_params"])
```

It always create a new Ensemble object with `metadata["ensemble_params"]` which is 
```python
metadata["ensemble_params"]
Out[1]: 
{'name': 'gnzl',
 'config_ffp': '/mnt/mantle_data/seistech/projects/v21p8p3/gnzl/v21p10emp_gnzl.yaml',
 'use_im_data_cache': False}
```
and they are identical regardless of the RPs and this class method is expensive.

Hence, instead of creating a new object that has exactly the same object attributes, pass the Ensemble we created and reuse them.

So with `gm_data.Ensemble.load` doesn't create a new Ensemble if the Ensemble is passed as an argument.

## Results
### Previous - Creating N number of Ensembles ( where N = number of RPs)
![image](https://user-images.githubusercontent.com/7849113/161156300-8d59bad4-166d-4910-95db-39c21de7602b.png)
### Current - Create only one Ensemble
![image](https://user-images.githubusercontent.com/7849113/161156321-20f09aa9-82d9-4647-a1ea-00a7490c6919.png)

### Comparing the JSON between old and new
The only difference between them is the download_token.
![image](https://user-images.githubusercontent.com/7849113/161156369-952c8681-45dc-4b9e-8381-e50c8aed42c0.png)

