### PR TITLE
Passing in a set as an indexer is deprecated; and we should use a list

### DIFF
--- a/calculation/gmhazard_calc/gmhazard_calc/gm_data/IMEnsemble.py
+++ b/calculation/gmhazard_calc/gmhazard_calc/gm_data/IMEnsemble.py
@@ -158,8 +158,8 @@ class IMEnsemble:
         )
 
     def __load_stations(self):
-        branch_stations = set.intersection(
+        branch_stations = list(set.intersection(
             *[set(branch.stations) for branch in self.branches_dict.values()]
-        ).intersection(self.ensemble.stations_ll_df.index)
+        ).intersection(self.ensemble.stations_ll_df.index))
 
         self._stations = self.ensemble.stations_ll_df.loc[branch_stations].sort_index()


### PR DESCRIPTION
```/home/jam335/code/gmhazard/calculation/gmhazard_calc/gmhazard_calc/gm_data/IMEnsemble.py:165: FutureWarning: Passing a set as an indexer is deprecated and will raise in a future version. Use a list instead.```

Fixing this guy