### PR TITLE
Add zbot for width

### DIFF
--- a/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/22p4.yaml
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/22p4.yaml
@@ -29,7 +29,6 @@
 ACTIVE_SHALLOW:
   PGV:
     geom:
-      - Br_10  # Br_10 or BSSA_14 or CB_14 or CY_14 or ASK_14
       - ASK_14
       - BSSA_14
       - CB_14

--- a/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/22p5.yaml
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/empirical_model_configs/22p5.yaml
@@ -29,7 +29,7 @@
 ACTIVE_SHALLOW:
   PGV:
     geom:
-      - Br_10  # ZA_06 or Br_10 or BSSA_14 or CB_14 or CY_14 or ASK_14
+#      - Br_10  # ZA_06 or Br_10 or BSSA_14 or CB_14 or CY_14 or ASK_14
       - ASK_14
       - BSSA_14
       - CB_14

--- a/tools/gmhazard_scripts/db_creation/empirical_db/new_calc_emp_ds.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/new_calc_emp_ds.py
@@ -13,7 +13,6 @@ from empirical.util import classdef
 from empirical.util import empirical_factory
 from empirical.util import openquake_wrapper_vectorized
 
-
 MAG = [
     5.25,
     5.75,
@@ -55,6 +54,8 @@ def create_rupture_context_df(
     # if there is only a single point then the dtop, dbot and hypo_depth
     # are at the same point
     rupture_df[["hypo_depth", "ztor"]] = rupture_df[["dbot", "dtop"]]
+    # zbot is not dbot but can be used as a proxy for point source, same reason above
+    rupture_df["zbot"] = rupture_df["dbot"]
 
     # Distance Parameter - OQ uses ry0 term
     rupture_df[["rx", "ry0"]] = rupture_df[["rx", "ry"]].fillna(0)
@@ -106,11 +107,6 @@ def calculate_emp_ds(
                     model_dict,
                 )
                 for GMM_idx, (GMM, _) in enumerate(GMMs):
-                    # TODO: Check those models
-                    if GMM.name in ("K_20", "K_20_NZ", "CB_14", "ASK_14"):
-                        print(f"{GMM.name} is currently not supported.")
-                        continue
-
                     db_type = f"{GMM.name}_{tect_type}"
                     # Create a DB if not exists
                     imdb = gc.dbs.IMDBParametric(

--- a/tools/gmhazard_scripts/db_creation/empirical_db/new_calc_emp_ds.py
+++ b/tools/gmhazard_scripts/db_creation/empirical_db/new_calc_emp_ds.py
@@ -53,9 +53,11 @@ def create_rupture_context_df(
     # hypo_depth is not dbot but can be used as a proxy for point source
     # if there is only a single point then the dtop, dbot and hypo_depth
     # are at the same point
-    rupture_df[["hypo_depth", "ztor"]] = rupture_df[["dbot", "dtop"]]
+    # Commented on 19/05/22 to use an average of dbot and dtop for hypo_depth
+    # to be more robust when supporting more models in the future.
+    rupture_df["hypo_depth"] = np.mean([rupture_df["dbot"], rupture_df["dtop"]], axis=0)
     # zbot is not dbot but can be used as a proxy for point source, same reason above
-    rupture_df["zbot"] = rupture_df["dbot"]
+    rupture_df[["ztor", "zbot"]] = rupture_df[["dtop", "dbot"]]
 
     # Distance Parameter - OQ uses ry0 term
     rupture_df[["rx", "ry0"]] = rupture_df[["rx", "ry"]].fillna(0)


### PR DESCRIPTION
# Add zbot for width

OQ's CB_14 needs a parameter called `zbot` to calculate a width.
(ZBOT (km) is the depth to the bottom of the seismogenic crust. from the paper.)

and based on the EE's approach, `zbot` is either `dbottom` or `hdepth`
![image](https://user-images.githubusercontent.com/7849113/168927649-1426bfcc-10b5-4c44-bf23-8a46812eb42f.png)

But, we already set `hypo_depth` to be `dbot`, so `zbot` will always be the `dbot`.
