### PR TITLE
Fix the core api tests

### DIFF
--- a/apis/core_api/core_api/test/test_core_scenarios.py
+++ b/apis/core_api/core_api/test/test_core_scenarios.py
@@ -21,7 +21,6 @@ def test_get_ensemble_scenario(config):
         (["ensemble_scenario", "mu_data"], dict),
         (["ensemble_scenario", "percentiles"], dict),
         (["ensemble_scenario", "percentiles", "16th"], dict),
-        (["ensemble_scenario", "percentiles", "50th"], dict),
         (["ensemble_scenario", "percentiles", "84th"], dict),
     ]
     tu.response_checks(


### PR DESCRIPTION
# Fix the core API tests

There are two failures:
1. GMS download - I need to spend more time on the investigation later.
2. Scenario compute

![image](https://user-images.githubusercontent.com/7849113/171533735-c23bad14-2bbb-42ff-861d-ab25bba2b414.png)

## 1. Scenario
As we updated a few calculations within the Scenarios and `percentiles_50th` is no longer a thing, remove them.

## 2. GMS
The error message is saying a missing `gms_token`.
![image](https://user-images.githubusercontent.com/7849113/171534057-63a9f2e7-090f-4f3d-aa03-9931f632b053.png)

However, when I ran it locally, it passed with no issues...
![image](https://user-images.githubusercontent.com/7849113/171534209-bfaa1087-787e-4250-bcfb-739d2471d722.png)

Based on the Slack messages,
Core API tests started failing from Monday.
![image](https://user-images.githubusercontent.com/7849113/171534525-2be1f93e-8880-4ae4-822d-b68da88cd777.png)

But nothing really changed between Saturday~Sunday, so I have no clues why this is happening.
![image](https://user-images.githubusercontent.com/7849113/171534627-162823a5-6e08-4e82-8c6a-1702e9148c88.png)

### Cannot reproduce the issue

For example, put exact same inputs on the public page
![image](https://user-images.githubusercontent.com/7849113/171538119-23ed2a12-78a0-4b16-a045-b394e1ddca6b.png)
![image](https://user-images.githubusercontent.com/7849113/171538186-17592be2-b122-422e-b81a-6091e8caade0.png)

But from the public page, we can download GMS data with no issues. (Same as running locally)
![image](https://user-images.githubusercontent.com/7849113/171538336-f8884f0c-1a7c-405e-8a63-1fb5992b509d.png)