### PR TITLE
Rename Return Period to Annual Exceedance Rate

### DIFF
--- a/frontend/src/components/Hazard/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Hazard/SeismicHazard/HazardViewerUHS.js
@@ -77,11 +77,11 @@ const HazardViewerUHS = () => {
     if (uhsData !== null) {
       const sortedSelectedRP = getExceedances()
         .sort((a, b) => {
-          return parseFloat(1 / Number(a)) - parseFloat(1 / Number(b));
+          return a - b;
         })
         .map((option) => ({
           value: option,
-          label: renderSigfigs(1 / Number(option), CONSTANTS.APP_UI_SIGFIGS),
+          label: renderSigfigs(option, CONSTANTS.APP_UI_SIGFIGS),
         }));
 
       setLocalSelectedRP(sortedSelectedRP[0]);
@@ -306,10 +306,7 @@ const HazardViewerUHS = () => {
                         : uhsBranchData[localSelectedRP["value"]]
                     }
                     nzs1170p5Data={uhsNZS1170p5Data[localSelectedRP["value"]]}
-                    rp={renderSigfigs(
-                      1 / Number(localSelectedRP["value"]),
-                      CONSTANTS.APP_UI_SIGFIGS
-                    )}
+                    rp={localSelectedRP["value"]}
                     extra={extraInfo}
                     showNZS1170p5={showUHSNZS1170p5}
                   />

--- a/frontend/src/components/Hazard/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Hazard/SeismicHazard/HazardViewerUHS.js
@@ -306,7 +306,7 @@ const HazardViewerUHS = () => {
                         : uhsBranchData[localSelectedRP["value"]]
                     }
                     nzs1170p5Data={uhsNZS1170p5Data[localSelectedRP["value"]]}
-                    rp={localSelectedRP["value"]}
+                    rate={localSelectedRP["value"]}
                     extra={extraInfo}
                     showNZS1170p5={showUHSNZS1170p5}
                   />

--- a/frontend/src/components/Hazard/SeismicHazard/UHSSection.js
+++ b/frontend/src/components/Hazard/SeismicHazard/UHSSection.js
@@ -69,7 +69,7 @@ const UHSSection = () => {
     return (
       <tr id={"uhs-row-" + idx} key={idx}>
         <td>
-          {renderSigfigs(rate, CONSTANTS.APP_UI_UHS_RATETABLE_RATE_SIGFIGS)}
+          {Number(renderSigfigs(rate, CONSTANTS.APP_UI_UHS_RATETABLE_RATE_SIGFIGS))}
         </td>
         <td>{returnPeriod}</td>
         <td>

--- a/frontend/src/components/Hazard/SeismicHazard/UHSSection.js
+++ b/frontend/src/components/Hazard/SeismicHazard/UHSSection.js
@@ -69,7 +69,7 @@ const UHSSection = () => {
     return (
       <tr id={"uhs-row-" + idx} key={idx}>
         <td>
-          {Number(renderSigfigs(rate, CONSTANTS.APP_UI_UHS_RATETABLE_RATE_SIGFIGS))}
+          {renderSigfigs(rate, CONSTANTS.APP_UI_UHS_RATETABLE_RATE_SIGFIGS)}
         </td>
         <td>{returnPeriod}</td>
         <td>

--- a/frontend/src/components/Project/SeismicHazard/DisaggregationSection.js
+++ b/frontend/src/components/Project/SeismicHazard/DisaggregationSection.js
@@ -45,8 +45,10 @@ const DisaggregationSection = () => {
         />
       </div>
       <div className="form-group">
+        <label className="control-label">
+          {CONSTANTS.ANNUAL_EXCEEDANCE_RATE} (years<sup>-1</sup>)
+        </label>
         <CustomSelect
-          title={`${CONSTANTS.RETURN_PERIOD} ${CONSTANTS.YEARS_UNIT}`}
           value={localSelectedRP}
           setSelect={setLocalSelectedRP}
           options={projectDisagRPs}

--- a/frontend/src/components/Project/SeismicHazard/DisaggregationSection.js
+++ b/frontend/src/components/Project/SeismicHazard/DisaggregationSection.js
@@ -52,6 +52,7 @@ const DisaggregationSection = () => {
           value={localSelectedRP}
           setSelect={setLocalSelectedRP}
           options={projectDisagRPs}
+          isAnnualExceedance={true}
         />
       </div>
 

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -263,7 +263,7 @@ const HazardViewerUHS = () => {
                         : uhsBranchData[localSelectedRP["value"]]
                     }
                     nzs1170p5Data={uhsNZS1170p5Data[localSelectedRP["value"]]}
-                    rp={localSelectedRP["label"]}
+                    rate={localSelectedRP["label"]}
                     extra={extraInfo}
                   />
                 </Fragment>

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -74,7 +74,7 @@ const HazardViewerUHS = () => {
         .sort((a, b) => a - b)
         .map((option) => ({
           value: 1 / Number(option),
-          label: option,
+          label: Number((1 / Number(option)).toFixed(4)),
         }));
 
       setLocalSelectedRP(sortedSelectedRP[0]);

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -146,9 +146,11 @@ const HazardViewerUHS = () => {
   };
 
   const updateUHSData = (uhsData) => {
-    setUHSData(filterUHSData(uhsData["uhs_results"], getSelectedRP()));
+    const selectedRPs = getSelectedRP();
+
+    setUHSData(filterUHSData(uhsData["uhs_results"], selectedRPs));
     setUHSNZS1170p5Data(
-      filterUHSData(uhsData["nzs1170p5_uhs_df"], getSelectedRP())
+      filterUHSData(uhsData["nzs1170p5_uhs_df"], selectedRPs)
     );
     setUHSBranchData(uhsData["branch_uhs_results"]);
     setDownloadToken(uhsData["download_token"]);
@@ -157,7 +159,7 @@ const HazardViewerUHS = () => {
       id: projectId,
       location: projectLocation,
       vs30: projectVS30,
-      selectedRPs: getSelectedRP(),
+      selectedRPs: selectedRPs,
     });
 
     setShowSpinnerUHS(false);

--- a/frontend/src/components/Project/SeismicHazard/UHSSection.js
+++ b/frontend/src/components/Project/SeismicHazard/UHSSection.js
@@ -8,14 +8,14 @@ import { GlobalContext } from "context";
 import * as CONSTANTS from "constants/Constants";
 
 import { GuideTooltip } from "components/common";
-import { createSelectArray, isPSANotInIMList } from "utils/Utils";
+import { createAnnualExceedanceArray, isPSANotInIMList } from "utils/Utils";
 
 const UHSSection = () => {
   const {
-    projectUHSRPs,
-    setProjectSelectedUHSRP,
-    setProjectUHSGetClick,
     projectIMs,
+    projectUHSRPs,
+    setProjectUHSGetClick,
+    setProjectSelectedUHSRP,
     projectSiteSelectionGetClick,
   } = useContext(GlobalContext);
 
@@ -28,7 +28,7 @@ const UHSSection = () => {
   useEffect(() => {
     setLocalRPs([]);
     if (projectUHSRPs.length !== 0) {
-      setRPOptions(createSelectArray(projectUHSRPs));
+      setRPOptions(createAnnualExceedanceArray(projectUHSRPs));
     } else {
       setRPOptions([]);
     }
@@ -54,7 +54,7 @@ const UHSSection = () => {
             htmlFor="uhs-return-period"
             className="control-label"
           >
-            {CONSTANTS.RETURN_PERIOD} {CONSTANTS.YEARS_UNIT}
+            {CONSTANTS.ANNUAL_EXCEEDANCE_RATE} (years<sup>-1</sup>)
           </label>
           <Select
             id="uhs-return-period"

--- a/frontend/src/components/common/CustomSelect.js
+++ b/frontend/src/components/common/CustomSelect.js
@@ -13,9 +13,10 @@ import * as CONSTANTS from "constants/Constants";
 
 import { GuideTooltip } from "components/common";
 import {
+  createZArray,
   createSelectArray,
   createProjectIDArray,
-  createZArray,
+  createAnnualExceedanceArray,
 } from "utils/Utils";
 
 const CustomSelect = ({
@@ -26,6 +27,7 @@ const CustomSelect = ({
   guideMSG = null,
   isProjectID = false,
   isZ = false,
+  isAnnualExceedance = false,
   resettable = true,
   resetOnChange = null,
 }) => {
@@ -41,6 +43,8 @@ const CustomSelect = ({
           ? createProjectIDArray(options)
           : isZ === true
           ? createZArray(options)
+          : isAnnualExceedance === true
+          ? createAnnualExceedanceArray(options)
           : createSelectArray(options);
 
       setLocalOptions(tempOptions);

--- a/frontend/src/components/common/GMS/GMSSpectraPlot.js
+++ b/frontend/src/components/common/GMS/GMSSpectraPlot.js
@@ -3,7 +3,7 @@ import React from "react";
 import Plot from "react-plotly.js";
 
 import * as CONSTANTS from "constants/Constants";
-import { createAxisLabel } from "utils/Utils.js";
+import { createAxisLabel } from "utils/Utils";
 
 import "assets/style/GMSPlot.css";
 

--- a/frontend/src/components/common/Scenarios/ScenarioPlot.js
+++ b/frontend/src/components/common/Scenarios/ScenarioPlot.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import Plot from "react-plotly.js";
 
-import { createAxisLabel } from "utils/Utils.js";
+import { createAxisLabel } from "utils/Utils";
 import { ErrorMessage } from "components/common";
 import * as CONSTANTS from "constants/Constants";
 

--- a/frontend/src/components/common/UHS/UHSBranchPlot.js
+++ b/frontend/src/components/common/UHS/UHSBranchPlot.js
@@ -16,7 +16,7 @@ const UHSBranchPlot = ({
   extra,
   showNZS1170p5 = true,
 }) => {
-  if (uhsData !== null && !uhsData.hasOwnProperty("error")) {
+  if (uhsData && !uhsData.hasOwnProperty("error")) {
     const createLegendLabel = (isNZCode) => {
       return isNZCode === true
         ? `${CONSTANTS.NZS1170P5} [Rate = ${rate}]`

--- a/frontend/src/components/common/UHS/UHSBranchPlot.js
+++ b/frontend/src/components/common/UHS/UHSBranchPlot.js
@@ -4,7 +4,7 @@ import Plot from "react-plotly.js";
 
 import * as CONSTANTS from "constants/Constants";
 import { ErrorMessage } from "components/common";
-import { getPlotData, createAxisLabel } from "utils/Utils.js";
+import { getPlotData, createAxisLabel } from "utils/Utils";
 
 import "assets/style/UHSPlot.css";
 

--- a/frontend/src/components/common/UHS/UHSBranchPlot.js
+++ b/frontend/src/components/common/UHS/UHSBranchPlot.js
@@ -19,8 +19,8 @@ const UHSBranchPlot = ({
   if (uhsData !== null && !uhsData.hasOwnProperty("error")) {
     const createLegendLabel = (isNZCode) => {
       return isNZCode === true
-        ? `${CONSTANTS.NZS1170P5} [RP = ${rp}]`
-        : `${CONSTANTS.SITE_SPECIFIC} [RP = ${rp}]`;
+        ? `${CONSTANTS.NZS1170P5} [Rate = ${rp}]`
+        : `${CONSTANTS.SITE_SPECIFIC} [Rate = ${rp}]`;
     };
 
     // Creating the scatter objects
@@ -53,29 +53,6 @@ const UHSBranchPlot = ({
       }
     }
 
-    // Create NZS1170p5 Code UHS scatter objs
-    // If object does not contain the value of NaN, we plot
-    if (!Object.values(nzs1170p5Data).includes("nan")) {
-      let nzs1170p5PlotData = getPlotData(nzs1170p5Data);
-      // Convert the Annual exdance reate to Return period in a string format
-      scatterObjs.push({
-        x: nzs1170p5PlotData.index,
-        y: nzs1170p5PlotData.values,
-        type: "scatter",
-        mode: "lines",
-        line: { color: "black" },
-        name: createLegendLabel(true),
-        visible: showNZS1170p5,
-        legendgroup: "NZS1170.5",
-        showlegend: true,
-        hoverinfo: "none",
-        hovertemplate:
-          `<b>${CONSTANTS.NZS1170P5} [RP ${rp}]</b><br><br>` +
-          "%{xaxis.title.text}: %{x}<br>" +
-          "%{yaxis.title.text}: %{y}<extra></extra>",
-      });
-    }
-
     // UHS scatter objs
     if (!uhsData.sa_values.includes("nan")) {
       // The first value is from PGA, hence do not inlcude
@@ -90,7 +67,7 @@ const UHSBranchPlot = ({
         showlegend: true,
         hoverinfo: "none",
         hovertemplate:
-          `<b>${CONSTANTS.SITE_SPECIFIC} [RP ${rp}]</b><br><br>` +
+          `<b>${CONSTANTS.SITE_SPECIFIC} [Rate = ${rp}]</b><br><br>` +
           "%{xaxis.title.text}: %{x}<br>" +
           "%{yaxis.title.text}: %{y}<extra></extra>",
       });
@@ -131,6 +108,29 @@ const UHSBranchPlot = ({
             "%{yaxis.title.text}: %{y}<extra></extra>",
         });
       }
+    }
+
+    // Create NZS1170p5 Code UHS scatter objs
+    // If object does not contain the value of NaN, we plot
+    if (!Object.values(nzs1170p5Data).includes("nan")) {
+      let nzs1170p5PlotData = getPlotData(nzs1170p5Data);
+      // Convert the Annual exdance reate to Return period in a string format
+      scatterObjs.push({
+        x: nzs1170p5PlotData.index,
+        y: nzs1170p5PlotData.values,
+        type: "scatter",
+        mode: "lines",
+        line: { color: "black" },
+        name: createLegendLabel(true),
+        visible: showNZS1170p5,
+        legendgroup: "NZS1170.5",
+        showlegend: true,
+        hoverinfo: "none",
+        hovertemplate:
+          `<b>${CONSTANTS.NZS1170P5} [Rate = ${rp}]</b><br><br>` +
+          "%{xaxis.title.text}: %{x}<br>" +
+          "%{yaxis.title.text}: %{y}<extra></extra>",
+      });
     }
 
     return (

--- a/frontend/src/components/common/UHS/UHSBranchPlot.js
+++ b/frontend/src/components/common/UHS/UHSBranchPlot.js
@@ -12,15 +12,15 @@ const UHSBranchPlot = ({
   uhsData,
   uhsBranchData,
   nzs1170p5Data,
-  rp,
+  rate,
   extra,
   showNZS1170p5 = true,
 }) => {
   if (uhsData !== null && !uhsData.hasOwnProperty("error")) {
     const createLegendLabel = (isNZCode) => {
       return isNZCode === true
-        ? `${CONSTANTS.NZS1170P5} [Rate = ${rp}]`
-        : `${CONSTANTS.SITE_SPECIFIC} [Rate = ${rp}]`;
+        ? `${CONSTANTS.NZS1170P5} [Rate = ${rate}]`
+        : `${CONSTANTS.SITE_SPECIFIC} [Rate = ${rate}]`;
     };
 
     // Creating the scatter objects
@@ -67,7 +67,7 @@ const UHSBranchPlot = ({
         showlegend: true,
         hoverinfo: "none",
         hovertemplate:
-          `<b>${CONSTANTS.SITE_SPECIFIC} [Rate = ${rp}]</b><br><br>` +
+          `<b>${CONSTANTS.SITE_SPECIFIC} [Rate = ${rate}]</b><br><br>` +
           "%{xaxis.title.text}: %{x}<br>" +
           "%{yaxis.title.text}: %{y}<extra></extra>",
       });
@@ -114,7 +114,6 @@ const UHSBranchPlot = ({
     // If object does not contain the value of NaN, we plot
     if (!Object.values(nzs1170p5Data).includes("nan")) {
       let nzs1170p5PlotData = getPlotData(nzs1170p5Data);
-      // Convert the Annual exdance reate to Return period in a string format
       scatterObjs.push({
         x: nzs1170p5PlotData.index,
         y: nzs1170p5PlotData.values,
@@ -127,7 +126,7 @@ const UHSBranchPlot = ({
         showlegend: true,
         hoverinfo: "none",
         hovertemplate:
-          `<b>${CONSTANTS.NZS1170P5} [Rate = ${rp}]</b><br><br>` +
+          `<b>${CONSTANTS.NZS1170P5} [Rate = ${rate}]</b><br><br>` +
           "%{xaxis.title.text}: %{x}<br>" +
           "%{yaxis.title.text}: %{y}<extra></extra>",
       });

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -9,7 +9,7 @@ import { getPlotData, createAxisLabel, convertRPtoAER } from "utils/Utils";
 import "assets/style/UHSPlot.css";
 
 const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
-  if (uhsData !== null && !uhsData.hasOwnProperty("error")) {
+  if (uhsData && !uhsData.hasOwnProperty("error")) {
     const createLegendLabel = (isNZCode) => {
       const selectedRPs = extra.selectedRPs;
 

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -4,7 +4,7 @@ import Plot from "react-plotly.js";
 
 import { ErrorMessage } from "components/common";
 import * as CONSTANTS from "constants/Constants";
-import { getPlotData, createAxisLabel } from "utils/Utils.js";
+import { getPlotData, createAxisLabel } from "utils/Utils";
 
 import "assets/style/UHSPlot.css";
 

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -15,7 +15,7 @@ const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
 
       selectedRPs.sort((a, b) => a - b);
       /*
-        Based on a sorted array, add each RP
+        Based on a sorted array, add each Annual Exceedance Rate
         Depends on the isNZCode status, newLabel starts with NZ Code - or an empty string
       */
       let newLabel =
@@ -24,7 +24,8 @@ const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
           : `${CONSTANTS.SITE_SPECIFIC} [Rate = `;
 
       /*
-        Only display to legend the RP that has values if its for Projects
+        Only display to legend the Annual Exceedance Rate
+        that has values if it's for Projects
       */
       if (extra.from === "project") {
         const dataToCheck = isNZCode === true ? nzs1170p5Data : uhsData;
@@ -34,6 +35,10 @@ const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
               dataToCheck[`${1 / Number(selectedRPs[i])}`]
             ).includes("nan")
           ) {
+            /* 
+            With projects, UHS is based on RP, not Annual Exceedance Rate.
+            Hence, we convert the selected RPs to Annual Exceedance Rate
+            */
             newLabel += `${convertRPtoAER(selectedRPs[i])}, `;
           }
         }
@@ -54,7 +59,6 @@ const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
     let dataCounter = 0;
     for (let [curExcd, curData] of Object.entries(uhsData)) {
       if (!curData.sa_values.includes("nan")) {
-        let displayRP = (1 / Number(curExcd)).toString();
         // The first value is from PGA, hence do not inlcude
         scatterObjs.push({
           x: curData.period_values.slice(1),
@@ -67,8 +71,8 @@ const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
           showlegend: dataCounter === 0 ? true : false,
           hoverinfo: "none",
           hovertemplate:
-            `<b>${CONSTANTS.SITE_SPECIFIC} [Rate = ${convertRPtoAER(
-              displayRP
+            `<b>${CONSTANTS.SITE_SPECIFIC} [Rate = ${Number(
+              Number(curExcd).toFixed(4)
             )}]</b><br><br>` +
             "%{xaxis.title.text}: %{x}<br>" +
             "%{yaxis.title.text}: %{y}<extra></extra>",
@@ -83,8 +87,6 @@ const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
       // Plots only if it does not include nan
       if (!Object.values(curData).includes("nan")) {
         let curPlotData = getPlotData(curData);
-        // Convert the Annual exdance reate to Return period in a string format
-        let displayRP = (1 / Number(curExcd)).toString();
         scatterObjs.push({
           x: curPlotData.index,
           y: curPlotData.values,
@@ -97,8 +99,8 @@ const UHSPlot = ({ uhsData, nzs1170p5Data, extra, showNZS1170p5 = true }) => {
           showlegend: nzCodeDataCounter === 0 ? true : false,
           hoverinfo: "none",
           hovertemplate:
-            `<b>${CONSTANTS.NZS1170P5} [Rate = ${convertRPtoAER(
-              displayRP
+            `<b>${CONSTANTS.NZS1170P5} [Rate = ${Number(
+              Number(curExcd).toFixed(4)
             )}]</b><br><br>` +
             "%{xaxis.title.text}: %{x}<br>" +
             "%{yaxis.title.text}: %{y}<extra></extra>",

--- a/frontend/src/constants/Constants.js
+++ b/frontend/src/constants/Constants.js
@@ -301,6 +301,7 @@ export const APP_LOCATION_DEFAULT_ENSEMBLE = "v20p5emp";
 export const APP_UI_CONTRIB_TABLE_ROWS = 10;
 export const APP_UI_VS30_DP = 1;
 export const APP_UI_SIGFIGS = 4;
+export const APP_UI_DECIFIGS = 4;
 export const APP_UI_UHS_RATETABLE_RATE_SIGFIGS = 3;
 
 export const UHS_TABLE_MESSAGE = "No rates added";

--- a/frontend/src/utils/Utils.js
+++ b/frontend/src/utils/Utils.js
@@ -84,7 +84,7 @@ export const getPlotData = (data) => {
 
 // Implement x sig figs for numeric float values
 export const renderSigfigs = (fullprecision, sigfigs) => {
-  return Number.parseFloat(fullprecision).toPrecision(sigfigs);
+  return parseFloat(fullprecision).toPrecision(sigfigs);
 };
 
 /* 

--- a/frontend/src/utils/Utils.js
+++ b/frontend/src/utils/Utils.js
@@ -3,8 +3,8 @@ import $ from "jquery";
 import * as CONSTANTS from "constants/Constants";
 
 /* 
-disable mousewheel on number input fields when in focus
-(to prevent Cromium browsers change the value when scrolling)
+  disable mousewheel on number input fields when in focus
+  (to prevent Cromium browsers change the value when scrolling)
 */
 export const disableScrollOnNumInput = () => {
   $("form").on("focus", "input[type=number]", (e) => {
@@ -27,23 +27,23 @@ export const disableScrollOnNumInput = () => {
 };
 
 /*
-Handle the response
-response is an array of objects if Promise.all is used
-response is an object if fetch is used
+  Handle the response
+  response is an array of objects if Promise.all is used
+  response is an object if fetch is used
 */
 export const handleErrors = (response) => {
   /*
-  For Promise.all with an empty array - Promise.all([])
-  With Hazard Curve, if IM is not PGA nor pSA_XX, we cannot get NZS1170.5 and NZTA.
-  Hence the response length will be 0
+    For Promise.all with an empty array - Promise.all([])
+    With Hazard Curve, if IM is not PGA nor pSA_XX, we cannot get NZS1170.5 and NZTA.
+    Hence the response length will be 0
   */
   if (response.length === 0) {
     return response;
   }
   /*
-  For Promise.all which is sending multiple requests simultaneously (array format)
-  However, single request is an object, not an array.
-  Hence, cannot use isArray() method
+    For Promise.all which is sending multiple requests simultaneously (array format)
+    However, single request is an object, not an array.
+    Hence, cannot use isArray() method
   */
   if (response.length >= 1) {
     for (const eachResponse of response) {
@@ -55,9 +55,9 @@ export const handleErrors = (response) => {
   } else {
     if (response.status !== 200) {
       /* 
-      Debug purpose
-      This can be replaced if we implement front-end logging just like we did on Core API (Saving logs in a file somehow)
-      Until then, console.log to invest while developing
+        Debug purpose
+        This can be replaced if we implement front-end logging just like we did on Core API (Saving logs in a file somehow)
+        Until then, console.log to invest while developing
       */
       console.log(Error(response.statusText));
       throw response.status;
@@ -68,8 +68,8 @@ export const handleErrors = (response) => {
 };
 
 /*
-Converts the Series json (which is a dict with each index value as a key),
-to two arrays ready for plotting.
+  Converts the Series json (which is a dict with each index value as a key),
+  to two arrays ready for plotting.
 */
 export const getPlotData = (data) => {
   const index = [];
@@ -88,11 +88,11 @@ export const renderSigfigs = (fullprecision, sigfigs) => {
 };
 
 /* 
-Create an Array from start to stop by step
-For instance, range(0, 1, 0.04) =
-[0, 0.04, 0.08, 0.12....., 1]
-To make empirical CDFs valid from 0-1 not just 1/N to 1
-Reference: https://en.wikipedia.org/wiki/Empirical_distribution_function
+  Create an Array from start to stop by step
+  For instance, range(0, 1, 0.04) =
+  [0, 0.04, 0.08, 0.12....., 1]
+  To make empirical CDFs valid from 0-1 not just 1/N to 1
+  Reference: https://en.wikipedia.org/wiki/Empirical_distribution_function
 */
 export const range = (start, stop, step) => {
   let tempArr = [start];
@@ -106,8 +106,8 @@ export const range = (start, stop, step) => {
 };
 
 /*
-Sort and duplicate every element
-Special sort & duplicate function for GMS Plots for X range
+  Sort and duplicate every element
+  Special sort & duplicate function for GMS Plots for X range
 */
 export const sortDuplicateXRange = (givenArr) => {
   return givenArr
@@ -118,9 +118,9 @@ export const sortDuplicateXRange = (givenArr) => {
 };
 
 /*
-Similar to sortDuplicateXRange() except it only duplicates 
-every element but the first and the last element.
-Special sort & duplicate function for GMS Plots for X range
+  Similar to sortDuplicateXRange() except it only duplicates 
+  every element but the first and the last element.
+  Special sort & duplicate function for GMS Plots for X range
 */
 export const sortDuplicateYRange = (givenArr) => {
   return givenArr.flatMap((x, i) =>
@@ -129,11 +129,11 @@ export const sortDuplicateYRange = (givenArr) => {
 };
 
 /*
-react-select required a form in an array of objects
-[{
-  value: value,
-  label: readable value to display as options
-},...]
+  react-select required a form in an array of objects
+  [{
+    value: value,
+    label: readable value to display as options
+  },...]
 */
 export const createSelectArray = (options) => {
   return options.map((option) => ({
@@ -143,8 +143,8 @@ export const createSelectArray = (options) => {
 };
 
 /*
-Designed for Disaggregation and UHS to display annual exceedance rate
-but sending RP to the backend
+  Designed for Disaggregation and UHS to display annual exceedance rate
+  but sending RP to the backend
 */
 export const createAnnualExceedanceArray = (options) => {
   return options.map((option) => ({
@@ -154,8 +154,8 @@ export const createAnnualExceedanceArray = (options) => {
 };
 
 /* 
-For react-select but different to above
-Specially made for Project IDs - value and label are different
+  For react-select but different to above
+  Specially made for Project IDs - value and label are different
 */
 export const createProjectIDArray = (options) => {
   let selectOptions = [];
@@ -168,8 +168,8 @@ export const createProjectIDArray = (options) => {
 };
 
 /* 
-For react-select but different to above
-Specially made for Projects Vs30 - label to contain unit, m/s
+  For react-select but different to above
+  Specially made for Projects Vs30 - label to contain unit, m/s
 */
 export const createVs30Array = (options) => {
   return options.map((option) => ({
@@ -179,8 +179,8 @@ export const createVs30Array = (options) => {
 };
 
 /* 
-For react-select but different to above
-Specially made for Projects Z1.0/Z2.5 - label to contain both Z1.0 and Z2.5 seperated and values to be a dictionary
+  For react-select but different to above
+  Specially made for Projects Z1.0/Z2.5 - label to contain both Z1.0 and Z2.5 seperated and values to be a dictionary
 */
 export const createZArray = (options) => {
   let selectOptions = options.map((option) => ({
@@ -202,8 +202,8 @@ export const isEmptyObj = (obj) => {
 };
 
 /* 
-Disable the UHS input field.
-if pSA not in IM list
+  Disable the UHS input field.
+  if pSA not in IM list
 */
 export const isPSANotInIMList = (givenIMList) => {
   return !givenIMList.includes("pSA");
@@ -233,9 +233,9 @@ export const GMSIMLabelConverter = (givenIM) => {
 };
 
 /* 
-Query string builder for API
-Parameters:
-Key and Value pair in an Object
+  Query string builder for API
+  Parameters:
+  Key and Value pair in an Object
 */
 export const APIQueryBuilder = (params) => {
   let queryString = "?";
@@ -263,14 +263,14 @@ export const createBoundsCoords = (xMin, xMax, yMin, yMax) => {
 };
 
 /*
-Convert the given return period into an annual exceedance rate
-in 4 decimal places
+  Convert the given return period into an annual exceedance rate
+  in 4 decimal places
 */
 export const convertRPtoAER = (RP) => Number((1 / Number(RP)).toFixed(4));
 
 /*
-JS version of qcore IM Sort
-Sort the IM Select dropdowns by the provided order
+  JS version of qcore IM Sort
+  Sort the IM Select dropdowns by the provided order
 */
 const DEFAULT_PATTERN_ORDER = [
   "station",
@@ -322,8 +322,8 @@ export const sortIMs = (unsortedIMs) => {
 };
 
 /*
-Returned IM contains periods (For now, pSA)
-Split the IM and Periods
+  Returned IM contains periods (For now, pSA)
+  Split the IM and Periods
 */
 export const splitIMPeriods = (IMs) => {
   const filteredIMs = [];
@@ -346,12 +346,12 @@ export const splitIMPeriods = (IMs) => {
 };
 
 /*
-Return combined IM with period
-if IM === pSA
-else IM
-In the future, instead of using IM === pSA
-ust an array to check if its in the list
-in case there are more than 1 IM with periods
+  Return combined IM with period
+  if IM === pSA
+  else IM
+  In the future, instead of using IM === pSA
+  ust an array to check if its in the list
+  in case there are more than 1 IM with periods
 */
 export const combineIMwithPeriod = (givenIM, givenPeriod) => {
   let combinedIM = givenIM;
@@ -385,7 +385,7 @@ export const createStationID = (
 };
 
 /*
-Create an axis label with symbol and unit
+  Create an axis label with symbol and unit
 */
 export const createAxisLabel = (name, symbol = null, unit = null) => {
   let axisLabel = `${name}`;

--- a/frontend/src/utils/Utils.js
+++ b/frontend/src/utils/Utils.js
@@ -1,8 +1,10 @@
 import $ from "jquery";
 
+import * as CONSTANTS from "constants/Constants";
+
 /* 
-  disable mousewheel on number input fields when in focus
-  (to prevent Cromium browsers change the value when scrolling)
+disable mousewheel on number input fields when in focus
+(to prevent Cromium browsers change the value when scrolling)
 */
 export const disableScrollOnNumInput = () => {
   $("form").on("focus", "input[type=number]", (e) => {
@@ -25,23 +27,23 @@ export const disableScrollOnNumInput = () => {
 };
 
 /*
-  Handle the response
-  response is an array of objects if Promise.all is used
-  response is an object if fetch is used
+Handle the response
+response is an array of objects if Promise.all is used
+response is an object if fetch is used
 */
 export const handleErrors = (response) => {
   /*
-    For Promise.all with an empty array - Promise.all([])
-    With Hazard Curve, if IM is not PGA nor pSA_XX, we cannot get NZS1170.5 and NZTA.
-    Hence the response length will be 0
+  For Promise.all with an empty array - Promise.all([])
+  With Hazard Curve, if IM is not PGA nor pSA_XX, we cannot get NZS1170.5 and NZTA.
+  Hence the response length will be 0
   */
   if (response.length === 0) {
     return response;
   }
   /*
-    For Promise.all which is sending multiple requests simultaneously (array format)
-    However, single request is an object, not an array.
-    Hence, cannot use isArray() method
+  For Promise.all which is sending multiple requests simultaneously (array format)
+  However, single request is an object, not an array.
+  Hence, cannot use isArray() method
   */
   if (response.length >= 1) {
     for (const eachResponse of response) {
@@ -53,9 +55,9 @@ export const handleErrors = (response) => {
   } else {
     if (response.status !== 200) {
       /* 
-        Debug purpose
-        This can be replaced if we implement front-end logging just like we did on Core API (Saving logs in a file somehow)
-        Until then, console.log to invest while developing
+      Debug purpose
+      This can be replaced if we implement front-end logging just like we did on Core API (Saving logs in a file somehow)
+      Until then, console.log to invest while developing
       */
       console.log(Error(response.statusText));
       throw response.status;
@@ -66,8 +68,8 @@ export const handleErrors = (response) => {
 };
 
 /*
-  Converts the Series json (which is a dict with each index value as a key),
-  to two arrays ready for plotting.
+Converts the Series json (which is a dict with each index value as a key),
+to two arrays ready for plotting.
 */
 export const getPlotData = (data) => {
   const index = [];
@@ -86,11 +88,11 @@ export const renderSigfigs = (fullprecision, sigfigs) => {
 };
 
 /* 
-  Create an Array from start to stop by step
-  For instance, range(0, 1, 0.04) =
-  [0, 0.04, 0.08, 0.12....., 1]
-  To make empirical CDFs valid from 0-1 not just 1/N to 1
-  Reference: https://en.wikipedia.org/wiki/Empirical_distribution_function
+Create an Array from start to stop by step
+For instance, range(0, 1, 0.04) =
+[0, 0.04, 0.08, 0.12....., 1]
+To make empirical CDFs valid from 0-1 not just 1/N to 1
+Reference: https://en.wikipedia.org/wiki/Empirical_distribution_function
 */
 export const range = (start, stop, step) => {
   let tempArr = [start];
@@ -104,8 +106,8 @@ export const range = (start, stop, step) => {
 };
 
 /*
-  Sort and duplicate every element
-  Special sort & duplicate function for GMS Plots for X range
+Sort and duplicate every element
+Special sort & duplicate function for GMS Plots for X range
 */
 export const sortDuplicateXRange = (givenArr) => {
   return givenArr
@@ -116,9 +118,9 @@ export const sortDuplicateXRange = (givenArr) => {
 };
 
 /*
-  Similar to sortDuplicateXRange() except it only duplicates 
-  every element but the first and the last element.
-  Special sort & duplicate function for GMS Plots for X range
+Similar to sortDuplicateXRange() except it only duplicates 
+every element but the first and the last element.
+Special sort & duplicate function for GMS Plots for X range
 */
 export const sortDuplicateYRange = (givenArr) => {
   return givenArr.flatMap((x, i) =>
@@ -127,11 +129,11 @@ export const sortDuplicateYRange = (givenArr) => {
 };
 
 /*
-  react-select required a form in an array of objects
-  [{
-    value: value,
-    label: readable value to display as options
-  },...]
+react-select required a form in an array of objects
+[{
+  value: value,
+  label: readable value to display as options
+},...]
 */
 export const createSelectArray = (options) => {
   return options.map((option) => ({
@@ -140,9 +142,20 @@ export const createSelectArray = (options) => {
   }));
 };
 
+/*
+Designed for Disaggregation and UHS to display annual exceedance rate
+but sending RP to the backend
+*/
+export const createAnnualExceedanceArray = (options) => {
+  return options.map((option) => ({
+    value: option,
+    label: parseFloat((1 / option).toFixed(CONSTANTS.APP_UI_DECIFIGS)),
+  }));
+};
+
 /* 
-  For react-select but different to above
-  Specially made for Project IDs - value and label are different
+For react-select but different to above
+Specially made for Project IDs - value and label are different
 */
 export const createProjectIDArray = (options) => {
   let selectOptions = [];
@@ -155,8 +168,8 @@ export const createProjectIDArray = (options) => {
 };
 
 /* 
-  For react-select but different to above
-  Specially made for Projects Vs30 - label to contain unit, m/s
+For react-select but different to above
+Specially made for Projects Vs30 - label to contain unit, m/s
 */
 export const createVs30Array = (options) => {
   return options.map((option) => ({
@@ -166,8 +179,8 @@ export const createVs30Array = (options) => {
 };
 
 /* 
-  For react-select but different to above
-  Specially made for Projects Z1.0/Z2.5 - label to contain both Z1.0 and Z2.5 seperated and values to be a dictionary
+For react-select but different to above
+Specially made for Projects Z1.0/Z2.5 - label to contain both Z1.0 and Z2.5 seperated and values to be a dictionary
 */
 export const createZArray = (options) => {
   let selectOptions = options.map((option) => ({
@@ -189,8 +202,8 @@ export const isEmptyObj = (obj) => {
 };
 
 /* 
-  Disable the UHS input field.
-  if pSA not in IM list
+Disable the UHS input field.
+if pSA not in IM list
 */
 export const isPSANotInIMList = (givenIMList) => {
   return !givenIMList.includes("pSA");
@@ -220,9 +233,9 @@ export const GMSIMLabelConverter = (givenIM) => {
 };
 
 /* 
-  Query string builder for API
-  Parameters:
-  Key and Value pair in an Object
+Query string builder for API
+Parameters:
+Key and Value pair in an Object
 */
 export const APIQueryBuilder = (params) => {
   let queryString = "?";
@@ -250,8 +263,8 @@ export const createBoundsCoords = (xMin, xMax, yMin, yMax) => {
 };
 
 /*
-  JS version of qcore IM Sort
-  Sort the IM Select dropdowns by the provided order
+JS version of qcore IM Sort
+Sort the IM Select dropdowns by the provided order
 */
 const DEFAULT_PATTERN_ORDER = [
   "station",
@@ -303,8 +316,8 @@ export const sortIMs = (unsortedIMs) => {
 };
 
 /*
-  Returned IM contains periods (For now, pSA)
-  Split the IM and Periods
+Returned IM contains periods (For now, pSA)
+Split the IM and Periods
 */
 export const splitIMPeriods = (IMs) => {
   const filteredIMs = [];
@@ -327,12 +340,12 @@ export const splitIMPeriods = (IMs) => {
 };
 
 /*
-  Return combined IM with period
-  if IM === pSA
-  else IM
-  In the future, instead of using IM === pSA
-  ust an array to check if its in the list
-  in case there are more than 1 IM with periods
+Return combined IM with period
+if IM === pSA
+else IM
+In the future, instead of using IM === pSA
+ust an array to check if its in the list
+in case there are more than 1 IM with periods
 */
 export const combineIMwithPeriod = (givenIM, givenPeriod) => {
   let combinedIM = givenIM;

--- a/frontend/src/utils/Utils.js
+++ b/frontend/src/utils/Utils.js
@@ -149,7 +149,7 @@ but sending RP to the backend
 export const createAnnualExceedanceArray = (options) => {
   return options.map((option) => ({
     value: option,
-    label: parseFloat((1 / option).toFixed(CONSTANTS.APP_UI_DECIFIGS)),
+    label: Number((1 / option).toFixed(CONSTANTS.APP_UI_DECIFIGS)),
   }));
 };
 
@@ -261,6 +261,12 @@ export const createBoundsCoords = (xMin, xMax, yMin, yMax) => {
     leftBoundY: [yMin, yMax],
   };
 };
+
+/*
+Convert the given return period into an annual exceedance rate
+in 4 decimal places
+*/
+export const convertRPtoAER = (RP) => Number((1 / Number(RP)).toFixed(4));
 
 /*
 JS version of qcore IM Sort


### PR DESCRIPTION
# Rename Return Period to Annual Exceedance Rate


UHS and Disaggregation are now working with an Annual Exceedance Rate

Also, a minor change, the order of plot drawing changed, so NZS1170.5 plot gets drawn in the last, so it comes at the very bottom of the list of legends. So it's like `branches`, `site-specific`, `percentiles`, then `nzcode`
![image](https://user-images.githubusercontent.com/7849113/173743604-8a8631cc-c9de-46fe-bb5d-88e4e31f2c3c.png)
![image](https://user-images.githubusercontent.com/7849113/173743787-904ea7b0-e70d-4b28-b759-41db23fdd855.png)

You might notice some remained RPs due to how the project API works in the backend.
For instance, UHS and Disagg, we return RPs instead of Annual Exceedance Rates
![image](https://user-images.githubusercontent.com/7849113/173744338-85e93fc0-8f8d-42b9-a432-702e3215ba49.png)
and these are because we passed Return Periods as inputs while generating the projects. Hence, RP is still needed, but when displayed on the frontend, they are converted into an Annual Exceedance Rate when needed.

