### PR TITLE
UHS with metadata

### DIFF
--- a/frontend/src/assets/style/MetadataBox.css
+++ b/frontend/src/assets/style/MetadataBox.css
@@ -6,7 +6,6 @@ div.custom-metadata-box {
   border-radius: 4px;
   color: red;
   background-color: #e9ecef;
-  font-size: 16px;
   resize: none;
 }
 

--- a/frontend/src/assets/style/MetadataBox.css
+++ b/frontend/src/assets/style/MetadataBox.css
@@ -1,0 +1,15 @@
+div.custom-metadata-box {
+  width: 100%;
+  padding: 12px 20px;
+  box-sizing: border-box;
+  border: 2px solid #ccc;
+  border-radius: 4px;
+  color: red;
+  background-color: #e9ecef;
+  font-size: 16px;
+  resize: none;
+}
+
+div.custom-metadata-box > p {
+  margin-bottom: 0;
+}

--- a/frontend/src/components/Hazard/SeismicHazard/HazardViewerHazardCurve.js
+++ b/frontend/src/components/Hazard/SeismicHazard/HazardViewerHazardCurve.js
@@ -7,17 +7,17 @@ import * as CONSTANTS from "constants/Constants";
 import { useAuth0 } from "components/common/ReactAuth0SPA";
 
 import {
-  LoadingSpinner,
-  DownloadButton,
+  MetadataBox,
   GuideMessage,
   ErrorMessage,
+  LoadingSpinner,
+  DownloadButton,
   HazardEnsemblePlot,
   HazardBranchPlot,
-  HazardCurveMetadata,
 } from "components/common";
 import {
-  APIQueryBuilder,
   handleErrors,
+  APIQueryBuilder,
   combineIMwithPeriod,
 } from "utils/Utils";
 
@@ -390,7 +390,7 @@ const HazardViewerHazardCurve = () => {
                   nztaData={hazardNZTAData}
                   extra={extraInfo}
                 />
-                <HazardCurveMetadata metadata={metadataParam} />
+                <MetadataBox metadata={metadataParam} />
               </Fragment>
             )}
         </Tab>
@@ -430,7 +430,7 @@ const HazardViewerHazardCurve = () => {
                   nztaData={hazardNZTAData}
                   extra={extraInfo}
                 />
-                <HazardCurveMetadata metadata={metadataParam} />
+                <MetadataBox metadata={metadataParam} />
               </Fragment>
             )}
         </Tab>

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
@@ -7,20 +7,20 @@ import * as CONSTANTS from "constants/Constants";
 import { useAuth0 } from "components/common/ReactAuth0SPA";
 
 import {
-  LoadingSpinner,
-  DownloadButton,
+  MetadataBox,
   GuideMessage,
   ErrorMessage,
+  LoadingSpinner,
+  DownloadButton,
   HazardEnsemblePlot,
   HazardBranchPlot,
-  HazardCurveMetadata,
 } from "components/common";
 import { getProjectHazardCurve } from "apis/ProjectAPI";
 import {
   handleErrors,
   APIQueryBuilder,
-  combineIMwithPeriod,
   createStationID,
+  combineIMwithPeriod,
 } from "utils/Utils";
 
 const HazardViewerHazardCurve = () => {
@@ -261,7 +261,7 @@ const HazardViewerHazardCurve = () => {
                   percentileData={percentileData}
                   extra={extraInfo}
                 />
-                <HazardCurveMetadata metadata={metadataParam} />
+                <MetadataBox metadata={metadataParam} />
               </Fragment>
             )}
         </Tab>
@@ -300,7 +300,7 @@ const HazardViewerHazardCurve = () => {
                   percentileData={percentileData}
                   extra={extraInfo}
                 />
-                <HazardCurveMetadata metadata={metadataParam} />
+                <MetadataBox metadata={metadataParam} />
               </Fragment>
             )}
         </Tab>

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
@@ -157,6 +157,8 @@ const HazardViewerHazardCurve = () => {
       Latitude: projectLat,
       Longitude: projectLng,
       Vs30: `${projectVS30} m/s`,
+      z1p0: `${projectZ1p0} km`,
+      z2p5: `${projectZ2p5} km`,
       "Intensity Measure": hazardData["im"],
     });
     setExtraInfo({
@@ -178,8 +180,8 @@ const HazardViewerHazardCurve = () => {
         setHazardNZTAData(hazardData["nzta_hazard"]["pga_values"]);
         setMetadataParam((prevState) => ({
           ...prevState,
-          "NZS1170.5 Z Factor": hazardData["nzs1170p5_hazard"]["Z"],
-          "NZS1170.5 Soil Class": hazardData["nzs1170p5_hazard"]["soil_class"],
+          "NZS 1170.5 Z Factor": hazardData["nzs1170p5_hazard"]["Z"],
+          "NZS 1170.5 Soil Class": hazardData["nzs1170p5_hazard"]["soil_class"],
           "NZTA Soil Class": hazardData["nzta_hazard"]["soil_class"],
         }));
       } else {
@@ -190,8 +192,8 @@ const HazardViewerHazardCurve = () => {
         setHazardNZTAData(null);
         setMetadataParam((prevState) => ({
           ...prevState,
-          "NZS1170.5 Z Factor": hazardData["nzs1170p5_hazard"]["Z"],
-          "NZS1170.5 Soil Class": hazardData["nzs1170p5_hazard"]["soil_class"],
+          "NZS 1170.5 Z Factor": hazardData["nzs1170p5_hazard"]["Z"],
+          "NZS 1170.5 Soil Class": hazardData["nzs1170p5_hazard"]["soil_class"],
         }));
       }
     } else if (projectSelectedIM === "pSA") {
@@ -202,8 +204,8 @@ const HazardViewerHazardCurve = () => {
       setHazardNZTAData(null);
       setMetadataParam((prevState) => ({
         ...prevState,
-        "NZS1170.5 Z Factor": hazardData["nzs1170p5_hazard"]["Z"],
-        "NZS1170.5 Soil Class": hazardData["nzs1170p5_hazard"]["soil_class"],
+        "NZS 1170.5 Z Factor": hazardData["nzs1170p5_hazard"]["Z"],
+        "NZS 1170.5 Soil Class": hazardData["nzs1170p5_hazard"]["soil_class"],
       }));
       if (projectSelectedIMComponent !== "Larger") {
         setMetadataParam((prevState) => ({

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerHazardCurve.js
@@ -12,8 +12,8 @@ import {
   ErrorMessage,
   LoadingSpinner,
   DownloadButton,
-  HazardEnsemblePlot,
   HazardBranchPlot,
+  HazardEnsemblePlot,
 } from "components/common";
 import { getProjectHazardCurve } from "apis/ProjectAPI";
 import {

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -9,11 +9,12 @@ import { useAuth0 } from "components/common/ReactAuth0SPA";
 
 import {
   UHSPlot,
+  MetadataBox,
+  ErrorMessage,
+  GuideMessage,
   UHSBranchPlot,
   LoadingSpinner,
   DownloadButton,
-  GuideMessage,
-  ErrorMessage,
 } from "components/common";
 import { getProjectUHS } from "apis/ProjectAPI";
 import { handleErrors, APIQueryBuilder, createStationID } from "utils/Utils";
@@ -27,6 +28,8 @@ const HazardViewerUHS = () => {
     projectVS30,
     projectZ1p0,
     projectZ2p5,
+    projectLat,
+    projectLng,
     projectLocationCode,
     projectSelectedUHSRP,
     setProjectSelectedUHSRP,
@@ -49,6 +52,9 @@ const HazardViewerUHS = () => {
   const [uhsBranchData, setUHSBranchData] = useState(null);
   const [uhsNZS1170p5Data, setUHSNZS1170p5Data] = useState(null);
   const [extraInfo, setExtraInfo] = useState({});
+
+  // For Metadata
+  const [metadataParam, setMetadataParam] = useState({});
 
   // For Download Data button
   const [downloadToken, setDownloadToken] = useState("");
@@ -154,6 +160,14 @@ const HazardViewerUHS = () => {
     );
     setUHSBranchData(uhsData["branch_uhs_results"]);
     setDownloadToken(uhsData["download_token"]);
+    setMetadataParam({
+      "Project Name": projectId["label"],
+      "Project ID": projectId["value"],
+      Location: projectLocation,
+      Latitude: projectLat,
+      Longitude: projectLng,
+      Vs30: `${projectVS30} m/s`,
+    });
     setExtraInfo({
       from: "project",
       id: projectId,
@@ -208,6 +222,7 @@ const HazardViewerUHS = () => {
                     nzs1170p5Data={uhsNZS1170p5Data}
                     extra={extraInfo}
                   />
+                  <MetadataBox metadata={metadataParam} />
                 </Fragment>
               )}
           </div>
@@ -266,6 +281,7 @@ const HazardViewerUHS = () => {
                     rate={localSelectedRP["label"]}
                     extra={extraInfo}
                   />
+                  <MetadataBox metadata={metadataParam} />
                 </Fragment>
               )}
           </div>

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -167,6 +167,8 @@ const HazardViewerUHS = () => {
       Latitude: projectLat,
       Longitude: projectLng,
       Vs30: `${projectVS30} m/s`,
+      z1p0: `${projectZ1p0} km`,
+      z2p5: `${projectZ2p5} km`,
     });
     setExtraInfo({
       from: "project",

--- a/frontend/src/components/common/MetadataBox.js
+++ b/frontend/src/components/common/MetadataBox.js
@@ -2,32 +2,55 @@ import React from "react";
 
 import * as CONSTANTS from "constants/Constants";
 
+import "assets/style/MetadataBox.css";
+
 const MetadataBox = ({ metadata }) => {
   const createMetadataText = () => {
-    let metadataText = "";
+    let metadataText = [];
+
     for (const [key, value] of Object.entries(metadata)) {
       if (key.includes("NZS1170.5 Soil")) {
-        metadataText += `${key}: ${CONSTANTS.NZS_SOIL_CLASS[value]}\n`;
+        metadataText.push(
+          <p key={key}>
+            {key}: {CONSTANTS.NZS_SOIL_CLASS[value]}
+          </p>
+        );
       } else if (key.includes("NZTA Soil")) {
-        metadataText += `${key}: ${CONSTANTS.NZTA_SOIL_CLASS[value]}\n`;
+        metadataText.push(
+          <p key={key}>
+            {key}: {CONSTANTS.NZTA_SOIL_CLASS[value]}
+          </p>
+        );
+      } else if (key.includes("Vs30")) {
+        metadataText.push(
+          <p key={key}>
+            V<sub>s30</sub>: {value}
+          </p>
+        );
+      } else if (key.includes("z1p0")) {
+        metadataText.push(
+          <p key={key}>
+            Z<sub>1.0</sub>: {value}
+          </p>
+        );
+      } else if (key.includes("z2p5")) {
+        metadataText.push(
+          <p key={key}>
+            Z<sub>2.5</sub>: {value}
+          </p>
+        );
       } else {
-        metadataText += `${key}: ${value}\n`;
+        metadataText.push(
+          <p key={key}>
+            {key}: {value}
+          </p>
+        );
       }
     }
 
-    return metadataText.slice(0, -1);
+    return metadataText;
   };
-  return (
-    <div className="form-group">
-      <textarea
-        style={{ color: "red", resize: "none" }}
-        className="form-control"
-        disabled
-        rows={Object.keys(metadata).length}
-        value={createMetadataText()}
-      ></textarea>
-    </div>
-  );
+  return <div className="custom-metadata-box">{createMetadataText()}</div>;
 };
 
 export default MetadataBox;

--- a/frontend/src/components/common/MetadataBox.js
+++ b/frontend/src/components/common/MetadataBox.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import * as CONSTANTS from "constants/Constants";
 
-const HazardCurveMetadata = ({ metadata }) => {
+const MetadataBox = ({ metadata }) => {
   const createMetadataText = () => {
     let metadataText = "";
     for (const [key, value] of Object.entries(metadata)) {
@@ -30,4 +30,4 @@ const HazardCurveMetadata = ({ metadata }) => {
   );
 };
 
-export default HazardCurveMetadata;
+export default MetadataBox;

--- a/frontend/src/components/common/MetadataBox.js
+++ b/frontend/src/components/common/MetadataBox.js
@@ -9,13 +9,17 @@ const MetadataBox = ({ metadata }) => {
     let metadataText = [];
 
     for (const [key, value] of Object.entries(metadata)) {
-      if (key.includes("NZS1170.5 Soil")) {
+      if (
+        key.includes("NZS") &&
+        key.includes("1170.5") &&
+        key.includes("Soil")
+      ) {
         metadataText.push(
           <p key={key}>
             {key}: {CONSTANTS.NZS_SOIL_CLASS[value]}
           </p>
         );
-      } else if (key.includes("NZTA Soil")) {
+      } else if (key.includes("NZTA") && key.includes("Soil")) {
         metadataText.push(
           <p key={key}>
             {key}: {CONSTANTS.NZTA_SOIL_CLASS[value]}

--- a/frontend/src/components/common/index.js
+++ b/frontend/src/components/common/index.js
@@ -45,7 +45,6 @@ export {
   ContributionTable,
   HazardBranchPlot,
   HazardEnsemblePlot,
-
   UHSPlot,
   UHSBranchPlot,
   ScenarioPlot,

--- a/frontend/src/components/common/index.js
+++ b/frontend/src/components/common/index.js
@@ -6,6 +6,7 @@ import GuideTooltip from "./GuideTooltip";
 import IMCustomSelect from "./IMCustomSelect";
 import Loading from "./Loading";
 import LoadingSpinner from "./LoadingSpinner";
+import MetadataBox from "./MetadataBox";
 import ModalComponent from "./ModalComponent";
 import SingleColumnView from "./SingleColumnView";
 import TwoColumnView from "./TwoColumnView";
@@ -14,11 +15,10 @@ import PermissionDashboard from "./PermissionConfig/PermissionDashboard";
 import ContributionTable from "./Disaggregation/ContributionTable";
 import HazardBranchPlot from "./HazardCurve/HazardBranchPlot";
 import HazardEnsemblePlot from "./HazardCurve/HazardEnsemblePlot";
-import HazardCurveMetadata from "./HazardCurve/HazardCurveMetadata";
+
 import UHSPlot from "./UHS/UHSPlot";
 import UHSBranchPlot from "./UHS/UHSBranchPlot";
 import ScenarioPlot from "./Scenarios/ScenarioPlot";
-
 import GMSAvailableGMPlot from "./GMS/GMSAvailableGMPlot";
 import GMSCausalParamPlot from "./GMS/GMSCausalParamPlot";
 import GMSDisaggDistributionPlot from "./GMS/GMSDisaggDistributionPlot";
@@ -37,6 +37,7 @@ export {
   IMCustomSelect,
   Loading,
   LoadingSpinner,
+  MetadataBox,
   ModalComponent,
   SingleColumnView,
   TwoColumnView,
@@ -44,7 +45,7 @@ export {
   ContributionTable,
   HazardBranchPlot,
   HazardEnsemblePlot,
-  HazardCurveMetadata,
+
   UHSPlot,
   UHSBranchPlot,
   ScenarioPlot,


### PR DESCRIPTION
# UHS with metadata


Projects' UHS now has a metadata box

MetadataBox component is updated with customized textarea instead of using <textarea> due to not supporting any HTML tag. E.g., superscript and subscript to support Vs30 and Z values
#### From
![image](https://user-images.githubusercontent.com/7849113/176095770-3ac672df-c235-4ef0-9435-1a20244adcad.png)
#### To
![image](https://user-images.githubusercontent.com/7849113/176095790-58a27916-7e47-494b-ad46-a41065a9f7db.png)

![image](https://user-images.githubusercontent.com/7849113/176095564-ae1c2eb3-f3c3-4149-aa2c-1abdcecaea44.png)



